### PR TITLE
variabilize/adjust to work with govcloud

### DIFF
--- a/modules/bastion/logging.tf
+++ b/modules/bastion/logging.tf
@@ -1,6 +1,6 @@
 # Create a log group for ssh accesss
 resource "aws_cloudwatch_log_group" "ssh-access-log-group" {
-  name              = "/aws/events/ssh-access"
+  name              = "/aws/events/${var.name}-ssh-access"
   retention_in_days = 60
   kms_key_id        = aws_kms_key.ssmkey.arn
 }
@@ -9,7 +9,7 @@ resource "aws_cloudwatch_log_group" "ssh-access-log-group" {
 resource "aws_cloudtrail" "ssh-access" {
   # checkov:skip=CKV_AWS_252: SNS not currently needed
   # checkov:skip=CKV2_AWS_10: Cloudwatch logs already being used with cloudtrail
-  name                       = "ssh-access"
+  name                       = "${var.name}-ssh-access"
   s3_bucket_name             = var.access_log_bucket_name
   kms_key_id                 = aws_kms_key.ssmkey.arn
   is_multi_region_trail      = true
@@ -26,7 +26,7 @@ resource "aws_cloudtrail" "ssh-access" {
 }
 
 resource "aws_cloudwatch_event_rule" "ssh-access" {
-  name        = "ssh-access"
+  name        = "${var.name}-ssh-access"
   description = "filters ssm access logs and sends usable data to a cloudwatch log group"
 
   event_pattern = <<EOF
@@ -43,7 +43,7 @@ EOF
 
 resource "aws_cloudwatch_event_target" "ssm-target" {
   rule      = aws_cloudwatch_event_rule.ssh-access.name
-  target_id = "ssh-access-target"
+  target_id = "${var.name}-ssh-access-target"
   arn       = aws_cloudwatch_log_group.ssh-access-log-group.arn
 }
 

--- a/modules/bastion/s3-buckets.tf
+++ b/modules/bastion/s3-buckets.tf
@@ -25,7 +25,7 @@ data "aws_iam_policy_document" "cloudwatch-policy" {
     ]
 
     resources = [
-      "arn:aws:s3:::${var.access_log_bucket_name}",
+      aws_s3_bucket.access_log_bucket.arn
     ]
 
     condition {
@@ -33,7 +33,7 @@ data "aws_iam_policy_document" "cloudwatch-policy" {
       variable = "AWS:SourceArn"
 
       values = [
-        "arn:aws:cloudtrail:${var.aws_region}:${data.aws_caller_identity.current.account_id}:trail/ssh-access",
+        "arn:${data.aws_partition.current.partition}:cloudtrail:${var.aws_region}:${data.aws_caller_identity.current.account_id}:trail/${var.name}-ssh-access",
       ]
     }
   }
@@ -52,7 +52,7 @@ data "aws_iam_policy_document" "cloudwatch-policy" {
     ]
 
     resources = [
-      "arn:aws:s3:::${var.access_log_bucket_name}/*",
+      "arn:${data.aws_partition.current.partition}:s3:::${var.access_log_bucket_name}/*",
     ]
 
     condition {
@@ -69,7 +69,7 @@ data "aws_iam_policy_document" "cloudwatch-policy" {
       variable = "AWS:SourceArn"
 
       values = [
-        "arn:aws:cloudtrail:${var.aws_region}:${data.aws_caller_identity.current.account_id}:trail/ssh-access",
+        "arn:${data.aws_partition.current.partition}:cloudtrail:${var.aws_region}:${data.aws_caller_identity.current.account_id}:trail/${var.name}-ssh-access",
       ]
     }
   }


### PR DESCRIPTION
Fixes problems occurring because of hard coded names and adjusts an IAM policy to work with both commercial and Gov AWS environments.