### PR TITLE
Fix Bastion S3 Access logging weirdness

### DIFF
--- a/modules/bastion/README.md
+++ b/modules/bastion/README.md
@@ -64,8 +64,7 @@ No modules.
 | [aws_s3_bucket_acl.session_logs_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_acl) | resource |
 | [aws_s3_bucket_lifecycle_configuration.access_log_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_lifecycle_configuration) | resource |
 | [aws_s3_bucket_lifecycle_configuration.session_logs_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_lifecycle_configuration) | resource |
-| [aws_s3_bucket_logging.access_logging_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_logging) | resource |
-| [aws_s3_bucket_logging.session_logs_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_logging) | resource |
+| [aws_s3_bucket_logging.access_logging_on_session_logs_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_logging) | resource |
 | [aws_s3_bucket_notification.access_log_bucket_notification](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_notification) | resource |
 | [aws_s3_bucket_notification.session_logs_bucket_notification](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_notification) | resource |
 | [aws_s3_bucket_policy.cloudwatch-s3-policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |

--- a/modules/bastion/s3-buckets.tf
+++ b/modules/bastion/s3-buckets.tf
@@ -1,7 +1,7 @@
 #####################################################
 ##################### S3 Bucket #####################
 
-# Create S3 bucket for access logs with versioning, encryption, blocked public acess enabled
+# Create S3 bucket for access logs with versioning, encryption, blocked public access enabled
 resource "aws_s3_bucket" "access_log_bucket" {
   # checkov:skip=CKV_AWS_144: Cross region replication is overkill
   bucket_prefix = "${var.access_log_bucket_name_prefix}-"
@@ -99,7 +99,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "access_log_bucket
   }
 }
 
-resource "aws_s3_bucket_logging" "access_logging_bucket" {
+resource "aws_s3_bucket_logging" "access_logging_on_session_logs_bucket" {
   bucket = aws_s3_bucket.session_logs_bucket.id
 
   target_bucket = aws_s3_bucket.access_log_bucket.id
@@ -169,13 +169,6 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "session_logs_buck
       sse_algorithm     = "aws:kms"
     }
   }
-}
-
-resource "aws_s3_bucket_logging" "session_logs_bucket" {
-  bucket = aws_s3_bucket.session_logs_bucket.id
-
-  target_bucket = aws_s3_bucket.session_logs_bucket.id
-  target_prefix = "log/"
 }
 
 resource "aws_s3_bucket_public_access_block" "session_logs_bucket" {


### PR DESCRIPTION
Closes #106
Closes #104 

Unless we really do need to have logs of who accessed the bucket that holds access logs (log-ception anyone?) this fixes the issue by just eliminating one of those `aws_s3_bucket_logging` resources.