### PR TITLE
Add role-duration-seconds to aws creds step in workflow

### DIFF
--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -147,6 +147,8 @@ jobs:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           role-session-name: ${{ github.event.client_payload.pull_request.head.sha || github.sha }}
           aws-region: us-east-1
+          # 21600 seconds == 6 hours
+          role-duration-seconds: 21600
 
       - name: "Run E2E tests"
         env:


### PR DESCRIPTION
There isn't really any way to confirm that this will work or not, since the workflow runs only use the pipeline configuration from `main` for security reasons. If it doesn't work I'll push up another PR to fix it ASAP.

This is needed because we hit the 1 hour default limit in a pipeline run:
<img width="1404" alt="image (2)" src="https://user-images.githubusercontent.com/16000938/228310031-9d2bdec1-4798-4729-974f-c2bdf36493cf.png">

