### PR TITLE
Rollback the polling validation of the sshuttle connection

### DIFF
--- a/test/e2e/examples_complete_secure_test.go
+++ b/test/e2e/examples_complete_secure_test.go
@@ -85,6 +85,8 @@ func TestExamplesCompleteSecure(t *testing.T) {
 	teststructure.RunTestStage(t, "SETUP", func() {
 		terraform.Init(t, terraformOptionsNoTargets)
 		terraform.Apply(t, terraformOptionsWithVPCAndBastionTargets)
+		// Wait 6 minutes for the bastion to be ready to accept connections
+		time.Sleep(6 * time.Minute)
 		bastionInstanceID := terraform.Output(t, terraformOutputOptions, "bastion_instance_id")
 		bastionPrivateDNS := terraform.Output(t, terraformOutputOptions, "bastion_private_dns")
 		//nolint:godox
@@ -129,32 +131,42 @@ func destroyWithSshuttle(t *testing.T, bastionInstanceID string, bastionPrivateD
 
 func runSshuttleInBackground(t *testing.T, bastionInstanceID string, bastionPrivateDNS string, bastionRegion string, bastionPassword string, vpcCidr string) (*exec.Cmd, error) {
 	t.Helper()
-	// Check that SShuttle is actually working by querying the bastion's private DNS, which will only work if sshuttle is working.
-	// If it works, it will return exit code 52 ("Empty reply from server"). Failure will most likely result in exit code 28 ("Couldn't connect to server"), but any result other than exit code 52 should be treated as a failure.
-	// We'll retry a few times in case the bastion is still starting up.
-	retryAttempts := 20
-	var sshuttleCmd *exec.Cmd
-	for i := 0; i < retryAttempts; i++ {
-		sshuttleCmd, err := startSshuttle(t, bastionInstanceID, bastionRegion, bastionPassword, vpcCidr)
-		if err != nil {
-			return nil, fmt.Errorf("failed to start sshuttle: %w", err)
-		}
-		time.Sleep(15 * time.Second) // It takes a few seconds for sshuttle to start up
-		curlCmd := exec.Command("curl", "-v", bastionPrivateDNS)
-		// We don't care about the output, just the exit code. Since we are looking for exit code 52, we should expect an error here.
-		_ = curlCmd.Run()
-		if curlCmd.ProcessState.ExitCode() == 52 {
-			// Success! sshuttle is working.
-			return sshuttleCmd, nil
-		}
-		// Failure. Try again.
-		doLog(fmt.Sprintf("sshuttle failed to start up. Retrying... (attempt %d of %d)", i+1, retryAttempts))
-		_ = stopSshuttle(t, sshuttleCmd)
+	doLog(bastionPrivateDNS)
+	sshuttleCmd, err := startSshuttle(t, bastionInstanceID, bastionRegion, bastionPassword, vpcCidr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to start sshuttle: %w", err)
 	}
-	// If we get here, we got through our for loop without verifying that sshuttle was working, so we should stop it and return an error.
-	_ = stopSshuttle(t, sshuttleCmd)
-	return nil, fmt.Errorf("failed to start sshuttle: could not verify that sshuttle was working")
+	return sshuttleCmd, nil
 }
+
+// func runSshuttleInBackground(t *testing.T, bastionInstanceID string, bastionPrivateDNS string, bastionRegion string, bastionPassword string, vpcCidr string) (*exec.Cmd, error) {
+// 	t.Helper()
+// 	// Check that SShuttle is actually working by querying the bastion's private DNS, which will only work if sshuttle is working.
+// 	// If it works, it will return exit code 52 ("Empty reply from server"). Failure will most likely result in exit code 28 ("Couldn't connect to server"), but any result other than exit code 52 should be treated as a failure.
+// 	// We'll retry a few times in case the bastion is still starting up.
+// 	retryAttempts := 20
+// 	var sshuttleCmd *exec.Cmd
+// 	for i := 0; i < retryAttempts; i++ {
+// 		sshuttleCmd, err := startSshuttle(t, bastionInstanceID, bastionRegion, bastionPassword, vpcCidr)
+// 		if err != nil {
+// 			return nil, fmt.Errorf("failed to start sshuttle: %w", err)
+// 		}
+// 		time.Sleep(15 * time.Second) // It takes a few seconds for sshuttle to start up
+// 		curlCmd := exec.Command("curl", "-v", bastionPrivateDNS)
+// 		// We don't care about the output, just the exit code. Since we are looking for exit code 52, we should expect an error here.
+// 		_ = curlCmd.Run()
+// 		if curlCmd.ProcessState.ExitCode() == 52 {
+// 			// Success! sshuttle is working.
+// 			return sshuttleCmd, nil
+// 		}
+// 		// Failure. Try again.
+// 		doLog(fmt.Sprintf("sshuttle failed to start up. Retrying... (attempt %d of %d)", i+1, retryAttempts))
+// 		_ = stopSshuttle(t, sshuttleCmd)
+// 	}
+// 	// If we get here, we got through our for loop without verifying that sshuttle was working, so we should stop it and return an error.
+// 	_ = stopSshuttle(t, sshuttleCmd)
+// 	return nil, fmt.Errorf("failed to start sshuttle: could not verify that sshuttle was working")
+// }
 
 func startSshuttle(t *testing.T, bastionInstanceID string, bastionRegion string, bastionPassword string, vpcCidr string) (*exec.Cmd, error) {
 	t.Helper()


### PR DESCRIPTION
and replace with a simple 6 minute wait, so that we can take the time to diagnose why the validation doesn't work without sitting there with a broken pipeline.