### PR TITLE
Simplify the naming convention for all resources

### DIFF
--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -126,9 +126,7 @@ kubectl get nodes
 
 | Name | Type |
 |------|------|
-| [random_id.bastion_name](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
-| [random_id.cluster_name](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
-| [random_id.vpc_name](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
+| [random_id.default](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
 | [aws_ami.amazonlinux2](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
@@ -145,13 +143,11 @@ kubectl get nodes
 | <a name="input_aws_admin_usernames"></a> [aws\_admin\_usernames](#input\_aws\_admin\_usernames) | A list of one or more AWS usernames with authorized access to KMS and EKS resources, will automatically add the user running the terraform as an admin | `list(string)` | `[]` | no |
 | <a name="input_aws_node_termination_handler_helm_config"></a> [aws\_node\_termination\_handler\_helm\_config](#input\_aws\_node\_termination\_handler\_helm\_config) | AWS Node Termination Handler Helm Chart config | `any` | `{}` | no |
 | <a name="input_bastion_instance_type"></a> [bastion\_instance\_type](#input\_bastion\_instance\_type) | value for the instance type of the EKS worker nodes | `string` | `"m5.xlarge"` | no |
-| <a name="input_bastion_name_prefix"></a> [bastion\_name\_prefix](#input\_bastion\_name\_prefix) | The name to use for the bastion | `string` | `"my-bastion"` | no |
 | <a name="input_bastion_ssh_password"></a> [bastion\_ssh\_password](#input\_bastion\_ssh\_password) | The SSH password to use for the bastion if SSM authentication is used | `string` | `"my-password"` | no |
 | <a name="input_bastion_ssh_user"></a> [bastion\_ssh\_user](#input\_bastion\_ssh\_user) | The SSH user to use for the bastion | `string` | `"ec2-user"` | no |
 | <a name="input_bastion_tenancy"></a> [bastion\_tenancy](#input\_bastion\_tenancy) | The tenancy of the bastion | `string` | `"default"` | no |
 | <a name="input_cluster_autoscaler_helm_config"></a> [cluster\_autoscaler\_helm\_config](#input\_cluster\_autoscaler\_helm\_config) | Cluster Autoscaler Helm Chart config | `any` | `{}` | no |
 | <a name="input_cluster_endpoint_public_access"></a> [cluster\_endpoint\_public\_access](#input\_cluster\_endpoint\_public\_access) | Whether to enable private access to the EKS cluster | `bool` | `false` | no |
-| <a name="input_cluster_name_prefix"></a> [cluster\_name\_prefix](#input\_cluster\_name\_prefix) | The name to use for the EKS cluster | `string` | `"my-eks"` | no |
 | <a name="input_cluster_version"></a> [cluster\_version](#input\_cluster\_version) | Kubernetes version to use for EKS cluster | `string` | `"1.23"` | no |
 | <a name="input_create_database_subnet_group"></a> [create\_database\_subnet\_group](#input\_create\_database\_subnet\_group) | Whether to create a database subnet group | `bool` | `true` | no |
 | <a name="input_create_database_subnet_route_table"></a> [create\_database\_subnet\_route\_table](#input\_create\_database\_subnet\_route\_table) | Whether to create a database subnet route table | `bool` | `true` | no |
@@ -175,10 +171,10 @@ kubectl get nodes
 | <a name="input_keycloak_enabled"></a> [keycloak\_enabled](#input\_keycloak\_enabled) | Whether to enable Keycloak | `bool` | `false` | no |
 | <a name="input_manage_aws_auth_configmap"></a> [manage\_aws\_auth\_configmap](#input\_manage\_aws\_auth\_configmap) | Determines whether to manage the aws-auth configmap | `bool` | `false` | no |
 | <a name="input_metrics_server_helm_config"></a> [metrics\_server\_helm\_config](#input\_metrics\_server\_helm\_config) | Metrics Server Helm Chart config | `any` | `{}` | no |
+| <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | The prefix to use when naming all resources | `string` | `"ex-complete"` | no |
 | <a name="input_region"></a> [region](#input\_region) | The AWS region to deploy into | `string` | n/a | yes |
 | <a name="input_region2"></a> [region2](#input\_region2) | The AWS region to deploy into | `string` | n/a | yes |
 | <a name="input_vpc_cidr"></a> [vpc\_cidr](#input\_vpc\_cidr) | The CIDR block for the VPC | `string` | n/a | yes |
-| <a name="input_vpc_name_prefix"></a> [vpc\_name\_prefix](#input\_vpc\_name\_prefix) | The name to use for the VPC | `string` | `"my-vpc"` | no |
 | <a name="input_zarf_version"></a> [zarf\_version](#input\_zarf\_version) | The version of Zarf to use | `string` | `""` | no |
 
 ## Outputs

--- a/examples/complete/fixtures.common.tfvars
+++ b/examples/complete/fixtures.common.tfvars
@@ -10,18 +10,17 @@
 #   Project     = "ci-eks"
 #   Owner       = "ci"
 # }
+name_prefix               = "ex-complete"
 manage_aws_auth_configmap = true
 
 ###########################################################
 #################### VPC Config ###########################
 
-vpc_cidr        = "10.200.0.0/16"
-vpc_name_prefix = "ex-complete-vpc-"
+vpc_cidr = "10.200.0.0/16"
 
 ###########################################################
 ################## Bastion Config #########################
 
-bastion_name_prefix  = "ex-complete-bastion-"
 bastion_ssh_user     = "ec2-user" # local user in bastion used to ssh
 bastion_ssh_password = "my-password"
 zarf_version         = "v0.24.0-rc4"
@@ -29,8 +28,7 @@ zarf_version         = "v0.24.0-rc4"
 ###########################################################
 #################### EKS Config ###########################
 
-cluster_name_prefix = "ex-complete-eks-"
-cluster_version     = "1.23"
+cluster_version = "1.23"
 
 ###########################################################
 ############## Big Bang Dependencies ######################

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -2,26 +2,15 @@ data "aws_partition" "current" {}
 
 data "aws_caller_identity" "current" {}
 
-resource "random_id" "vpc_name" {
+resource "random_id" "default" {
   byte_length = 2
-  prefix      = var.vpc_name_prefix
-}
-
-resource "random_id" "cluster_name" {
-  byte_length = 2
-  prefix      = var.cluster_name_prefix
-}
-
-resource "random_id" "bastion_name" {
-  byte_length = 2
-  prefix      = var.bastion_name_prefix
 }
 
 locals {
-  vpc_name         = lower(random_id.vpc_name.hex)
-  cluster_name     = lower(random_id.cluster_name.hex)
-  bastion_name     = lower(random_id.bastion_name.hex)
-  loki_name_prefix = "${lower(random_id.cluster_name.hex)}-loki"
+  vpc_name         = "${var.name_prefix}-${lower(random_id.default.hex)}"
+  cluster_name     = "${var.name_prefix}-${lower(random_id.default.hex)}"
+  bastion_name     = "${var.name_prefix}-bastion-${lower(random_id.default.hex)}"
+  loki_name_prefix = "${var.name_prefix}-loki-${lower(random_id.default.hex)}"
 
   account = data.aws_caller_identity.current.account_id
 

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -11,6 +11,16 @@ variable "region2" {
   type        = string
 }
 
+variable "name_prefix" {
+  description = "The prefix to use when naming all resources"
+  type        = string
+  default     = "ex-complete"
+  validation {
+    condition     = length(var.name_prefix) <= 20
+    error_message = "The name prefix cannot be more than 20 characters"
+  }
+}
+
 variable "aws_admin_usernames" {
   description = "A list of one or more AWS usernames with authorized access to KMS and EKS resources, will automatically add the user running the terraform as an admin"
   type        = list(string)
@@ -36,16 +46,6 @@ variable "vpc_cidr" {
   type        = string
 }
 
-variable "vpc_name_prefix" {
-  description = "The name to use for the VPC"
-  type        = string
-  default     = "my-vpc"
-  validation {
-    condition     = length(var.vpc_name_prefix) <= 20
-    error_message = "The VPC name prefix cannot be more than 20 characters"
-  }
-}
-
 variable "create_database_subnet_group" {
   description = "Whether to create a database subnet group"
   type        = bool
@@ -64,16 +64,6 @@ variable "eks_worker_tenancy" {
   description = "The tenancy of the EKS worker nodes"
   type        = string
   default     = "default"
-}
-
-variable "cluster_name_prefix" {
-  description = "The name to use for the EKS cluster"
-  type        = string
-  default     = "my-eks"
-  validation {
-    condition     = length(var.cluster_name_prefix) <= 20
-    error_message = "The EKS cluster name prefix cannot be more than 20 characters"
-  }
 }
 
 variable "cluster_version" {
@@ -226,16 +216,6 @@ variable "bastion_tenancy" {
   description = "The tenancy of the bastion"
   type        = string
   default     = "default"
-}
-
-variable "bastion_name_prefix" {
-  description = "The name to use for the bastion"
-  type        = string
-  default     = "my-bastion"
-  validation {
-    condition     = length(var.bastion_name_prefix) <= 20
-    error_message = "The Bastion name prefix cannot be more than 20 characters"
-  }
 }
 
 variable "bastion_instance_type" {

--- a/modules/s3-irsa/README.md
+++ b/modules/s3-irsa/README.md
@@ -23,7 +23,7 @@ To view examples for how you can leverage this S3-IRSA Module, please see the [e
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | terraform-aws-modules/s3-bucket/aws | v3.6.0 |
+| <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | terraform-aws-modules/s3-bucket/aws | v3.8.2 |
 
 ## Resources
 

--- a/modules/s3-irsa/main.tf
+++ b/modules/s3-irsa/main.tf
@@ -11,7 +11,7 @@ data "aws_partition" "current" {}
 ################## Loki S3 Bucket ###################
 module "s3_bucket" {
   source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "v3.6.0"
+  version = "v3.8.2"
 
   bucket_prefix           = var.name_prefix
   block_public_acls       = true
@@ -42,6 +42,8 @@ resource "aws_s3_bucket_logging" "logging" {
 
   target_bucket = module.s3_bucket.s3_bucket_id
   target_prefix = "log/"
+
+  depends_on = [module.s3_bucket.s3_bucket_id]
 }
 
 resource "aws_kms_key" "objects" {


### PR DESCRIPTION
This PR simplifies the naming convention for all resources, by using a single variable instead of one for each module. It also fixes an issue where different randomized IDs were being generated for each module, which makes it more confusing to track down which resources belong to which test run.