### PR TITLE
Fix typo in Bastion module -- "Sylog" -> "Syslog"

### DIFF
--- a/modules/bastion/logging.tf
+++ b/modules/bastion/logging.tf
@@ -89,43 +89,43 @@ resource "aws_ssm_parameter" "cloudwatch_configuration_file" {
             {
               "file_path" : "/var/log/messages",
               "log_group_name" : "ec2-cloudwatch-logging-${var.name}",
-              "log_stream_name" : "Sylog",
+              "log_stream_name" : "Syslog",
               "retention_in_days" : 60
             },
             {
               "file_path" : "/var/log/boot.log*",
               "log_group_name" : "ec2-cloudwatch-logging-${var.name}",
-              "log_stream_name" : "Sylog",
+              "log_stream_name" : "Syslog",
               "retention_in_days" : 60
             },
             {
               "file_path" : "/var/log/secure",
               "log_group_name" : "ec2-cloudwatch-logging-${var.name}",
-              "log_stream_name" : "Sylog",
+              "log_stream_name" : "Syslog",
               "retention_in_days" : 60
             },
             {
               "file_path" : "/var/log/messages",
               "log_group_name" : "ec2-cloudwatch-logging-${var.name}",
-              "log_stream_name" : "Sylog",
+              "log_stream_name" : "Syslog",
               "retention_in_days" : 60
             },
             {
               "file_path" : "/var/log/cron*",
               "log_group_name" : "ec2-cloudwatch-logging-${var.name}",
-              "log_stream_name" : "Sylog",
+              "log_stream_name" : "Syslog",
               "retention_in_days" : 60
             },
             {
               "file_path" : "/var/log/cloud-init-output.log",
               "log_group_name" : "ec2-cloudwatch-logging-${var.name}",
-              "log_stream_name" : "Sylog",
+              "log_stream_name" : "Syslog",
               "retention_in_days" : 60
             },
             {
               "file_path" : "/var/log/dmesg",
               "log_group_name" : "ec2-cloudwatch-logging-${var.name}",
-              "log_stream_name" : "Sylog",
+              "log_stream_name" : "Syslog",
               "retention_in_days" : 60
             },
           ]


### PR DESCRIPTION
Fixes typos in #144 . Sylog ---> Syslog