### PR TITLE
Fixes this error we've been getting about cannot create an ACL

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -4,7 +4,7 @@ checkov 2.3.3
 golang 1.19.5
 golangci-lint 1.50.1
 pre-commit 3.0.1
-terraform 1.3.9
+terraform 1.4.4
 terraform-docs 0.16.0
 tflint 0.44.1
 tfsec 1.28.1

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # The version of the build harness container to use
 BUILD_HARNESS_REPO := ghcr.io/defenseunicorns/not-a-build-harness/not-a-build-harness
-BUILD_HARNESS_VERSION := 0.0.12
+BUILD_HARNESS_VERSION := 0.0.13
 
 .DEFAULT_GOAL := help
 

--- a/modules/bastion/README.md
+++ b/modules/bastion/README.md
@@ -67,6 +67,7 @@ No modules.
 | [aws_s3_bucket_logging.access_logging_on_session_logs_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_logging) | resource |
 | [aws_s3_bucket_notification.access_log_bucket_notification](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_notification) | resource |
 | [aws_s3_bucket_notification.session_logs_bucket_notification](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_notification) | resource |
+| [aws_s3_bucket_ownership_controls.session_logs_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_ownership_controls) | resource |
 | [aws_s3_bucket_policy.cloudwatch-s3-policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
 | [aws_s3_bucket_public_access_block.access_log_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
 | [aws_s3_bucket_public_access_block.session_logs_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |

--- a/modules/bastion/s3-buckets.tf
+++ b/modules/bastion/s3-buckets.tf
@@ -154,9 +154,10 @@ resource "aws_s3_bucket_ownership_controls" "session_logs_bucket" {
 }
 
 resource "aws_s3_bucket_acl" "session_logs_bucket" {
-  bucket = aws_s3_bucket.session_logs_bucket.id
+  depends_on = [aws_s3_bucket_ownership_controls.session_logs_bucket]
 
-  acl = "private"
+  bucket = aws_s3_bucket.session_logs_bucket.id
+  acl    = "private"
 }
 
 resource "aws_s3_bucket_versioning" "session_logs_bucket" {

--- a/modules/bastion/s3-buckets.tf
+++ b/modules/bastion/s3-buckets.tf
@@ -146,6 +146,13 @@ resource "aws_s3_bucket" "session_logs_bucket" {
 
 }
 
+resource "aws_s3_bucket_ownership_controls" "session_logs_bucket" {
+  bucket = aws_s3_bucket.session_logs_bucket.id
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
 resource "aws_s3_bucket_acl" "session_logs_bucket" {
   bucket = aws_s3_bucket.session_logs_bucket.id
 


### PR DESCRIPTION
Closes #159 

Error: error creating S3 bucket ACL for ex-complete-bastion-72f1-sessionlogs-20230411160015023000000003: AccessControlListNotSupported: The bucket does not allow ACLs