### PR TITLE
Remove restore key from terraform cache step

### DIFF
--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -150,7 +150,6 @@ jobs:
         with:
           path: "${{ github.workspace }}/.cache/.terraform.d/plugin-cache"
           key: "${{ runner.os }}-terraform-plugins|${{ steps.get_tf_version.outputs.tf_version }}|${{ hashFiles('examples/complete/providers.tf') }}"
-          restore-keys: ${{ runner.os }}-terraform-plugins
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1


### PR DESCRIPTION
We don't believe it is necessary and may be causing an issue with the terraform caching step.