### PR TITLE
Run `terraform init` before running the E2E tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ _test-all: _create-folders
 		-v "${PWD}/.cache/go:/root/go" \
 		-v "${PWD}/.cache/go-build:/root/.cache/go-build" \
 		-v "${PWD}/.cache/.terraform.d/plugin-cache:/root/.terraform.d/plugin-cache" \
-		--workdir "/app/test/e2e" \
+		--workdir "/app" \
 		-e TF_LOG_PATH \
 		-e TF_LOG \
 		-e GOPATH=/root/go \
@@ -60,7 +60,7 @@ _test-all: _create-folders
 		-e SKIP_TEST \
 		-e SKIP_TEARDOWN \
 		$(BUILD_HARNESS_REPO):$(BUILD_HARNESS_VERSION) \
-		bash -c 'asdf install && go test -count 1 -v $(EXTRA_TEST_ARGS) .'
+		bash -c 'asdf install && cd examples/complete && terraform init && cd ../../test/e2e && go test -count 1 -v $(EXTRA_TEST_ARGS) .'
 
 .PHONY: bastion-connect
 bastion-connect: _create-folders ## To be used after deploying "secure mode" of examples/complete. It (a) creates a tunnel through the bastion host using sshuttle, and (b) sets up the KUBECONFIG so that the EKS cluster is able to be interacted with. Requires the standard AWS cred environment variables to be set. We recommend using 'aws-vault' to set them.

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ _test-all: _create-folders
 		-e SKIP_TEST \
 		-e SKIP_TEARDOWN \
 		$(BUILD_HARNESS_REPO):$(BUILD_HARNESS_VERSION) \
-		bash -c 'asdf install && cd examples/complete && terraform init && cd ../../test/e2e && go test -count 1 -v $(EXTRA_TEST_ARGS) .'
+		bash -c 'asdf install && cd examples/complete && terraform init -upgrade=true && cd ../../test/e2e && go test -count 1 -v $(EXTRA_TEST_ARGS) .'
 
 .PHONY: bastion-connect
 bastion-connect: _create-folders ## To be used after deploying "secure mode" of examples/complete. It (a) creates a tunnel through the bastion host using sshuttle, and (b) sets up the KUBECONFIG so that the EKS cluster is able to be interacted with. Requires the standard AWS cred environment variables to be set. We recommend using 'aws-vault' to set them.

--- a/test/e2e/examples_complete_insecure_test.go
+++ b/test/e2e/examples_complete_insecure_test.go
@@ -12,7 +12,7 @@ func TestExamplesCompleteInsecure(t *testing.T) {
 	tempFolder := teststructure.CopyTerraformFolderToTemp(t, "../..", "examples/complete")
 	terraformOptions := &terraform.Options{
 		TerraformDir: tempFolder,
-		Upgrade:      true,
+		Upgrade:      false,
 		VarFiles: []string{
 			"fixtures.common.tfvars",
 			"fixtures.insecure.tfvars",
@@ -25,7 +25,7 @@ func TestExamplesCompleteInsecure(t *testing.T) {
 func setupTestExamplesCompleteInsecure(t *testing.T, terraformOptions *terraform.Options) {
 	t.Helper()
 	teststructure.RunTestStage(t, "SETUP", func() {
-		terraform.Apply(t, terraformOptions)
+		terraform.InitAndApply(t, terraformOptions)
 	})
 }
 

--- a/test/e2e/examples_complete_insecure_test.go
+++ b/test/e2e/examples_complete_insecure_test.go
@@ -25,7 +25,7 @@ func TestExamplesCompleteInsecure(t *testing.T) {
 func setupTestExamplesCompleteInsecure(t *testing.T, terraformOptions *terraform.Options) {
 	t.Helper()
 	teststructure.RunTestStage(t, "SETUP", func() {
-		terraform.InitAndApply(t, terraformOptions)
+		terraform.Apply(t, terraformOptions)
 	})
 }
 

--- a/test/e2e/examples_complete_secure_test.go
+++ b/test/e2e/examples_complete_secure_test.go
@@ -24,9 +24,12 @@ import (
 func TestExamplesCompleteSecure(t *testing.T) {
 	t.Parallel()
 	tempFolder := teststructure.CopyTerraformFolderToTemp(t, "../..", "examples/complete")
+	terraformInitOptions := &terraform.Options{
+		TerraformDir: tempFolder,
+		Upgrade:      true,
+	}
 	terraformOptionsNoTargets := &terraform.Options{
 		TerraformDir: tempFolder,
-		Upgrade:      false,
 		VarFiles: []string{
 			"fixtures.common.tfvars",
 			"fixtures.secure.tfvars",
@@ -34,7 +37,6 @@ func TestExamplesCompleteSecure(t *testing.T) {
 	}
 	terraformOptionsWithVPCAndBastionTargets := &terraform.Options{
 		TerraformDir: tempFolder,
-		Upgrade:      false,
 		VarFiles: []string{
 			"fixtures.common.tfvars",
 			"fixtures.secure.tfvars",
@@ -46,7 +48,6 @@ func TestExamplesCompleteSecure(t *testing.T) {
 	}
 	terraformOptionsWithEKSTarget := &terraform.Options{
 		TerraformDir: tempFolder,
-		Upgrade:      false,
 		VarFiles: []string{
 			"fixtures.common.tfvars",
 			"fixtures.secure.tfvars",
@@ -83,7 +84,7 @@ func TestExamplesCompleteSecure(t *testing.T) {
 	}()
 	// setupTestExamplesCompleteSecure(t, terraformOptionsNoTargets, terraformOptionsWithVPCAndBastionTargets)
 	teststructure.RunTestStage(t, "SETUP", func() {
-		terraform.Init(t, terraformOptionsNoTargets)
+		terraform.Init(t, terraformInitOptions)
 		terraform.Apply(t, terraformOptionsWithVPCAndBastionTargets)
 		bastionInstanceID := terraform.Output(t, terraformOutputOptions, "bastion_instance_id")
 		bastionPrivateDNS := terraform.Output(t, terraformOutputOptions, "bastion_private_dns")

--- a/test/e2e/examples_complete_secure_test.go
+++ b/test/e2e/examples_complete_secure_test.go
@@ -24,10 +24,6 @@ import (
 func TestExamplesCompleteSecure(t *testing.T) {
 	t.Parallel()
 	tempFolder := teststructure.CopyTerraformFolderToTemp(t, "../..", "examples/complete")
-	terraformInitOptions := &terraform.Options{
-		TerraformDir: tempFolder,
-		Upgrade:      true,
-	}
 	terraformOptionsNoTargets := &terraform.Options{
 		TerraformDir: tempFolder,
 		VarFiles: []string{
@@ -84,7 +80,6 @@ func TestExamplesCompleteSecure(t *testing.T) {
 	}()
 	// setupTestExamplesCompleteSecure(t, terraformOptionsNoTargets, terraformOptionsWithVPCAndBastionTargets)
 	teststructure.RunTestStage(t, "SETUP", func() {
-		terraform.Init(t, terraformInitOptions)
 		terraform.Apply(t, terraformOptionsWithVPCAndBastionTargets)
 		bastionInstanceID := terraform.Output(t, terraformOutputOptions, "bastion_instance_id")
 		bastionPrivateDNS := terraform.Output(t, terraformOutputOptions, "bastion_private_dns")

--- a/test/e2e/examples_complete_secure_test.go
+++ b/test/e2e/examples_complete_secure_test.go
@@ -25,6 +25,10 @@ import (
 func TestExamplesCompleteSecure(t *testing.T) {
 	t.Parallel()
 	tempFolder := teststructure.CopyTerraformFolderToTemp(t, "../..", "examples/complete")
+	terraformInitOptions := &terraform.Options{
+		TerraformDir: tempFolder,
+		Upgrade:      false,
+	}
 	terraformOptionsNoTargets := &terraform.Options{
 		TerraformDir: tempFolder,
 		VarFiles: []string{
@@ -81,6 +85,7 @@ func TestExamplesCompleteSecure(t *testing.T) {
 	}()
 	// setupTestExamplesCompleteSecure(t, terraformOptionsNoTargets, terraformOptionsWithVPCAndBastionTargets)
 	teststructure.RunTestStage(t, "SETUP", func() {
+		terraform.Init(t, terraformInitOptions)
 		terraform.Apply(t, terraformOptionsWithVPCAndBastionTargets)
 		bastionInstanceID := terraform.Output(t, terraformOutputOptions, "bastion_instance_id")
 		bastionPrivateDNS := terraform.Output(t, terraformOutputOptions, "bastion_private_dns")


### PR DESCRIPTION
Run `terraform init` before running the E2E tests due to [this issue](https://github.com/hashicorp/terraform/issues/25849)