### PR TITLE
Remove EFS creation token

### DIFF
--- a/modules/eks/main.tf
+++ b/modules/eks/main.tf
@@ -119,8 +119,7 @@ module "efs" {
 
   count = var.enable_efs ? 1 : 0
 
-  creation_token = local.name
-  name           = lower(random_id.efs_name.hex)
+  name = lower(random_id.efs_name.hex)
   # Mount targets / security group
   mount_targets = {
     for k, v in zipmap(local.availability_zone_name, var.private_subnet_ids) : k => { subnet_id = v }


### PR DESCRIPTION
Removing previous creation token and relying on AWS randomization for the EFS ID.