### PR TITLE
Bastion Module: Stop creating a Key Pair

### DIFF
--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -201,7 +201,6 @@ kubectl get nodes
 |------|-------------|
 | <a name="output_bastion_instance_id"></a> [bastion\_instance\_id](#output\_bastion\_instance\_id) | The ID of the bastion host |
 | <a name="output_bastion_private_dns"></a> [bastion\_private\_dns](#output\_bastion\_private\_dns) | The private DNS address of the bastion host |
-| <a name="output_bastion_private_key"></a> [bastion\_private\_key](#output\_bastion\_private\_key) | The private key for the bastion host |
 | <a name="output_bastion_region"></a> [bastion\_region](#output\_bastion\_region) | The region that the bastion host was deployed to |
 | <a name="output_dynamodb_name"></a> [dynamodb\_name](#output\_dynamodb\_name) | Name of DynmoDB table |
 | <a name="output_eks_cluster_name"></a> [eks\_cluster\_name](#output\_eks\_cluster\_name) | The name of the EKS cluster |

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -43,12 +43,6 @@ output "bastion_region" {
   sensitive   = true
 }
 
-output "bastion_private_key" {
-  description = "The private key for the bastion host"
-  value       = module.bastion.private_key
-  sensitive   = true
-}
-
 output "bastion_private_dns" {
   description = "The private DNS address of the bastion host"
   value       = module.bastion.private_dns

--- a/modules/bastion/README.md
+++ b/modules/bastion/README.md
@@ -93,7 +93,6 @@ No modules.
 | <a name="input_assign_public_ip"></a> [assign\_public\_ip](#input\_assign\_public\_ip) | Determines if an instance gets a public IP assigned at launch time | `bool` | `false` | no |
 | <a name="input_cloudwatch_log_group_name"></a> [cloudwatch\_log\_group\_name](#input\_cloudwatch\_log\_group\_name) | Name of the CloudWatch Log Group for storing SSM Session Logs | `string` | `"/ssm/session-logs"` | no |
 | <a name="input_cloudwatch_logs_retention"></a> [cloudwatch\_logs\_retention](#input\_cloudwatch\_logs\_retention) | Number of days to retain Session Logs in CloudWatch | `number` | `30` | no |
-| <a name="input_enable_kms_key_rotation"></a> [enable\_kms\_key\_rotation](#input\_enable\_kms\_key\_rotation) | Toggle to optionally enable kms key rotation. Defaults to true | `bool` | `true` | no |
 | <a name="input_enable_log_to_cloudwatch"></a> [enable\_log\_to\_cloudwatch](#input\_enable\_log\_to\_cloudwatch) | Enable Session Manager to Log to CloudWatch Logs | `bool` | `true` | no |
 | <a name="input_enable_log_to_s3"></a> [enable\_log\_to\_s3](#input\_enable\_log\_to\_s3) | Enable Session Manager to Log to S3 | `bool` | `true` | no |
 | <a name="input_enable_sqs_events_on_bastion_login"></a> [enable\_sqs\_events\_on\_bastion\_login](#input\_enable\_sqs\_events\_on\_bastion\_login) | If true, generates an SQS event whenever an object is created in the Session Logs S3 bucket, which happens whenever someone logs in to the Bastion. | `bool` | `false` | no |
@@ -133,7 +132,6 @@ No modules.
 | <a name="output_primary_network_interface_id"></a> [primary\_network\_interface\_id](#output\_primary\_network\_interface\_id) | Primary Network Interface Id |
 | <a name="output_private_dns"></a> [private\_dns](#output\_private\_dns) | Private DNS |
 | <a name="output_private_ip"></a> [private\_ip](#output\_private\_ip) | Private IP |
-| <a name="output_private_key"></a> [private\_key](#output\_private\_key) | n/a |
 | <a name="output_public_ip"></a> [public\_ip](#output\_public\_ip) | Public IP |
 | <a name="output_region"></a> [region](#output\_region) | Region the bastion was deployed to |
 | <a name="output_security_group_ids"></a> [security\_group\_ids](#output\_security\_group\_ids) | Security Group Ids |

--- a/modules/bastion/README.md
+++ b/modules/bastion/README.md
@@ -21,7 +21,6 @@ To view examples for how you can leverage this Bastion, please see the [examples
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.72 |
 | <a name="provider_cloudinit"></a> [cloudinit](#provider\_cloudinit) | n/a |
-| <a name="provider_tls"></a> [tls](#provider\_tls) | n/a |
 
 ## Modules
 
@@ -53,7 +52,6 @@ No modules.
 | [aws_iam_role_policy_attachment.s3_logging_cube](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.terraform](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_instance.application](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance) | resource |
-| [aws_key_pair.bastion_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/key_pair) | resource |
 | [aws_network_interface_attachment.attach](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_interface_attachment) | resource |
 | [aws_s3_bucket.session_logs_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket_acl.session_logs_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_acl) | resource |
@@ -68,7 +66,6 @@ No modules.
 | [aws_sqs_queue.bastion_login_queue](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sqs_queue) | resource |
 | [aws_ssm_document.session_manager_prefs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_document) | resource |
 | [aws_ssm_parameter.cloudwatch_configuration_file](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
-| [tls_private_key.bastion_key](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |
 | [aws_ami.from_filter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy.AmazonSSMManagedInstanceCore](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy) | data source |

--- a/modules/bastion/main.tf
+++ b/modules/bastion/main.tf
@@ -38,10 +38,8 @@ data "aws_kms_key" "default" {
 
 resource "aws_instance" "application" {
   #checkov:skip=CKV2_AWS_41: IAM role is created in the module
-  ami           = var.ami_id != "" ? var.ami_id : data.aws_ami.from_filter[0].id
-  instance_type = var.instance_type
-  # key_name                    = var.ec2_key_name
-  key_name                    = aws_key_pair.bastion_key.key_name
+  ami                         = var.ami_id != "" ? var.ami_id : data.aws_ami.from_filter[0].id
+  instance_type               = var.instance_type
   vpc_security_group_ids      = length(local.security_group_configs) > 0 ? aws_security_group.sg.*.id : var.security_group_ids
   user_data                   = data.cloudinit_config.config.rendered
   iam_instance_profile        = local.role_name == "" ? null : aws_iam_instance_profile.bastion_ssm_profile.name
@@ -65,16 +63,6 @@ resource "aws_instance" "application" {
     var.tags,
     { Name = var.name }
   )
-}
-
-resource "tls_private_key" "bastion_key" {
-  algorithm = "RSA"
-  rsa_bits  = 4096
-}
-
-resource "aws_key_pair" "bastion_key" {
-  key_name   = "${var.name}-key"
-  public_key = tls_private_key.bastion_key.public_key_openssh
 }
 
 resource "aws_network_interface_attachment" "attach" {

--- a/modules/bastion/output.tf
+++ b/modules/bastion/output.tf
@@ -37,11 +37,6 @@ output "session_logs_bucket_arn" {
   description = "Session Logs Bucket ARN"
 }
 
-output "private_key" {
-  value     = tls_private_key.bastion_key.private_key_pem
-  sensitive = true
-}
-
 output "bastion_role_name" {
   value       = aws_iam_role.bastion_ssm_role.name
   description = "Bastion Role Name"

--- a/modules/bastion/ssm.tf
+++ b/modules/bastion/ssm.tf
@@ -12,7 +12,7 @@ resource "aws_ssm_document" "session_manager_prefs" {
     inputs = {
       s3BucketName                = var.enable_log_to_s3 ? aws_s3_bucket.session_logs_bucket.id : ""
       s3EncryptionEnabled         = var.enable_log_to_s3 ? true : false
-      cloudWatchLogGroupName      = var.enable_log_to_cloudwatch ? aws_cloudwatch_log_group.session_manager_log_group[*].name : ""
+      cloudWatchLogGroupName      = var.enable_log_to_cloudwatch ? aws_cloudwatch_log_group.session_manager_log_group[0].name : ""
       cloudWatchEncryptionEnabled = var.enable_log_to_cloudwatch ? true : false
       kmsKeyId                    = data.aws_kms_key.default.id
       shellProfile = {

--- a/modules/bastion/variables.tf
+++ b/modules/bastion/variables.tf
@@ -176,12 +176,6 @@ variable "enable_log_to_cloudwatch" {
   default     = true
 }
 
-variable "enable_kms_key_rotation" {
-  description = "Toggle to optionally enable kms key rotation. Defaults to true"
-  type        = bool
-  default     = true
-}
-
 #####################################################
 ##################### user data #####################
 


### PR DESCRIPTION
### Changes

* Delete the Bastion's Key Pair
* Delete an unused variable in the bastion module

closes #186 

We don't need a Key Pair because the method we use to log into the bastion (Session Manager) doesn't need it.