### PR TITLE
Addon updates

### DIFF
--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -147,8 +147,6 @@ kubectl get nodes
 |------|-------------|------|---------|:--------:|
 | <a name="input_access_log_expire_days"></a> [access\_log\_expire\_days](#input\_access\_log\_expire\_days) | Number of days to wait before deleting access logs | `number` | `30` | no |
 | <a name="input_amazon_eks_aws_ebs_csi_driver_config"></a> [amazon\_eks\_aws\_ebs\_csi\_driver\_config](#input\_amazon\_eks\_aws\_ebs\_csi\_driver\_config) | configMap for AWS EBS CSI Driver add-on | `any` | `{}` | no |
-| <a name="input_amazon_eks_coredns_config"></a> [amazon\_eks\_coredns\_config](#input\_amazon\_eks\_coredns\_config) | Configuration for Amazon CoreDNS EKS add-on | `any` | `{}` | no |
-| <a name="input_amazon_eks_kube_proxy_config"></a> [amazon\_eks\_kube\_proxy\_config](#input\_amazon\_eks\_kube\_proxy\_config) | ConfigMap for Amazon EKS Kube-Proxy add-on | `any` | `{}` | no |
 | <a name="input_assign_public_ip"></a> [assign\_public\_ip](#input\_assign\_public\_ip) | Whether to assign a public IP to the bastion | `bool` | `false` | no |
 | <a name="input_aws_admin_usernames"></a> [aws\_admin\_usernames](#input\_aws\_admin\_usernames) | A list of one or more AWS usernames with authorized access to KMS and EKS resources, will automatically add the user running the terraform as an admin | `list(string)` | `[]` | no |
 | <a name="input_aws_node_termination_handler_helm_config"></a> [aws\_node\_termination\_handler\_helm\_config](#input\_aws\_node\_termination\_handler\_helm\_config) | AWS Node Termination Handler Helm Chart config | `any` | `{}` | no |
@@ -167,8 +165,6 @@ kubectl get nodes
 | <a name="input_dataplane_wait_duration"></a> [dataplane\_wait\_duration](#input\_dataplane\_wait\_duration) | Duration to wait after the EKS cluster has become active before creating the dataplane components (EKS managed nodegroup(s), self-managed nodegroup(s), Fargate profile(s)) | `string` | `"2m"` | no |
 | <a name="input_eks_worker_tenancy"></a> [eks\_worker\_tenancy](#input\_eks\_worker\_tenancy) | The tenancy of the EKS worker nodes | `string` | `"default"` | no |
 | <a name="input_enable_amazon_eks_aws_ebs_csi_driver"></a> [enable\_amazon\_eks\_aws\_ebs\_csi\_driver](#input\_enable\_amazon\_eks\_aws\_ebs\_csi\_driver) | Enable EKS Managed AWS EBS CSI Driver add-on; enable\_amazon\_eks\_aws\_ebs\_csi\_driver and enable\_self\_managed\_aws\_ebs\_csi\_driver are mutually exclusive | `bool` | `false` | no |
-| <a name="input_enable_amazon_eks_coredns"></a> [enable\_amazon\_eks\_coredns](#input\_enable\_amazon\_eks\_coredns) | Enable Amazon EKS CoreDNS add-on | `bool` | `false` | no |
-| <a name="input_enable_amazon_eks_kube_proxy"></a> [enable\_amazon\_eks\_kube\_proxy](#input\_enable\_amazon\_eks\_kube\_proxy) | Enable Kube Proxy add-on | `bool` | `false` | no |
 | <a name="input_enable_aws_node_termination_handler"></a> [enable\_aws\_node\_termination\_handler](#input\_enable\_aws\_node\_termination\_handler) | Enable AWS Node Termination Handler add-on | `bool` | `false` | no |
 | <a name="input_enable_calico"></a> [enable\_calico](#input\_enable\_calico) | Enable Calico add-on | `bool` | `true` | no |
 | <a name="input_enable_cluster_autoscaler"></a> [enable\_cluster\_autoscaler](#input\_enable\_cluster\_autoscaler) | Enable Cluster autoscaler add-on | `bool` | `false` | no |

--- a/examples/complete/fixtures.common.tfvars
+++ b/examples/complete/fixtures.common.tfvars
@@ -65,24 +65,52 @@ cluster_addons = {
       }
     JSON
   }
+  coredns = {
+    preserve    = true
+    most_recent = true
+
+    timeouts = {
+      create = "25m"
+      delete = "10m"
+    }
+  }
+  kube-proxy = {
+    most_recent = true
+  }
 }
 
 
 #################### Blueprints addons ###################
 #wait false for all addons, as it times out on teardown in the test pipeline
-enable_cluster_autoscaler      = true
-cluster_autoscaler_helm_config = { wait = false }
-
-enable_amazon_eks_aws_ebs_csi_driver = true
-amazon_eks_aws_ebs_csi_driver_config = { wait = false }
-
-enable_metrics_server      = true
-metrics_server_helm_config = { wait = false }
-
-enable_aws_node_termination_handler      = false
-aws_node_termination_handler_helm_config = { wait = false }
-
-enable_calico      = true
-calico_helm_config = { wait = false }
 
 enable_efs = true
+
+enable_amazon_eks_aws_ebs_csi_driver = true
+amazon_eks_aws_ebs_csi_driver_config = {
+  wait        = false
+  most_recent = true
+}
+
+enable_aws_node_termination_handler = true
+aws_node_termination_handler_helm_config = {
+  wait    = false
+  version = "v0.21.0"
+}
+
+enable_cluster_autoscaler = true
+cluster_autoscaler_helm_config = {
+  wait    = false
+  version = "v9.28.0"
+}
+
+enable_metrics_server = true
+metrics_server_helm_config = {
+  wait    = false
+  version = "v3.10.0"
+}
+
+enable_calico = true
+calico_helm_config = {
+  wait    = false
+  version = "v3.25.1"
+}

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -191,7 +191,7 @@ module "eks" {
   control_plane_subnet_ids        = module.vpc.private_subnets
   source_security_group_id        = module.bastion.security_group_ids[0]
   cluster_endpoint_public_access  = var.cluster_endpoint_public_access
-  dataplane_wait_duration         = var.data_plane_wait_duration
+  dataplane_wait_duration         = var.dataplane_wait_duration
   cluster_endpoint_private_access = true
   vpc_cni_custom_subnet           = module.vpc.intra_subnets
   aws_admin_usernames             = var.aws_admin_usernames

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -258,31 +258,23 @@ module "eks" {
   # EKS Blueprints - EKS Add-Ons
   #---------------------------------------------------------------
 
-  # EKS CoreDNS
-  enable_amazon_eks_coredns = var.enable_amazon_eks_coredns
-  amazon_eks_coredns_config = var.amazon_eks_coredns_config
-
-  # EKS kube-proxy
-  enable_amazon_eks_kube_proxy = var.enable_amazon_eks_kube_proxy
-  amazon_eks_kube_proxy_config = var.amazon_eks_kube_proxy_config
-
-  # EKS EBS CSI Driver
+  # AWS EKS EBS CSI Driver
   enable_amazon_eks_aws_ebs_csi_driver = var.enable_amazon_eks_aws_ebs_csi_driver
   amazon_eks_aws_ebs_csi_driver_config = var.amazon_eks_aws_ebs_csi_driver_config
 
-  # EKS EFS CSI Driver
+  # AWS EKS EFS CSI Driver
   enable_efs     = var.enable_efs
   reclaim_policy = var.reclaim_policy
 
-  # EKS Metrics Server
-  enable_metrics_server      = var.enable_metrics_server
-  metrics_server_helm_config = var.metrics_server_helm_config
-
-  # EKS AWS node termination handler
+  # AWS EKS node termination handler
   enable_aws_node_termination_handler      = var.enable_aws_node_termination_handler
   aws_node_termination_handler_helm_config = var.aws_node_termination_handler_helm_config
 
-  # EKS Cluster Autoscaler
+  # k8s Metrics Server
+  enable_metrics_server      = var.enable_metrics_server
+  metrics_server_helm_config = var.metrics_server_helm_config
+
+  # k8s Cluster Autoscaler
   enable_cluster_autoscaler      = var.enable_cluster_autoscaler
   cluster_autoscaler_helm_config = var.cluster_autoscaler_helm_config
 

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -144,32 +144,6 @@ EOD
   default     = {}
 }
 
-#----------------AWS CoreDNS-------------------------
-variable "enable_amazon_eks_coredns" {
-  description = "Enable Amazon EKS CoreDNS add-on"
-  type        = bool
-  default     = false
-}
-
-variable "amazon_eks_coredns_config" {
-  description = "Configuration for Amazon CoreDNS EKS add-on"
-  type        = any
-  default     = {}
-}
-
-#----------------AWS Kube Proxy-------------------------
-variable "enable_amazon_eks_kube_proxy" {
-  description = "Enable Kube Proxy add-on"
-  type        = bool
-  default     = false
-}
-
-variable "amazon_eks_kube_proxy_config" {
-  description = "ConfigMap for Amazon EKS Kube-Proxy add-on"
-  type        = any
-  default     = {}
-}
-
 #----------------AWS EBS CSI Driver-------------------------
 variable "enable_amazon_eks_aws_ebs_csi_driver" {
   description = "Enable EKS Managed AWS EBS CSI Driver add-on; enable_amazon_eks_aws_ebs_csi_driver and enable_self_managed_aws_ebs_csi_driver are mutually exclusive"

--- a/modules/eks/README.md
+++ b/modules/eks/README.md
@@ -31,7 +31,7 @@ To view examples for how you can leverage this EKS Module, please see the [examp
 |------|--------|---------|
 | <a name="module_aws_eks"></a> [aws\_eks](#module\_aws\_eks) | git::https://github.com/terraform-aws-modules/terraform-aws-eks.git | v19.13.1 |
 | <a name="module_efs"></a> [efs](#module\_efs) | terraform-aws-modules/efs/aws | ~> 1.0 |
-| <a name="module_eks_blueprints_kubernetes_addons"></a> [eks\_blueprints\_kubernetes\_addons](#module\_eks\_blueprints\_kubernetes\_addons) | git::https://github.com/aws-ia/terraform-aws-eks-blueprints.git//modules/kubernetes-addons | v4.27.0 |
+| <a name="module_eks_blueprints_kubernetes_addons"></a> [eks\_blueprints\_kubernetes\_addons](#module\_eks\_blueprints\_kubernetes\_addons) | git::https://github.com/aws-ia/terraform-aws-eks-blueprints.git//modules/kubernetes-addons | v4.29.0 |
 
 ## Resources
 
@@ -54,8 +54,6 @@ To view examples for how you can leverage this EKS Module, please see the [examp
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_amazon_eks_aws_ebs_csi_driver_config"></a> [amazon\_eks\_aws\_ebs\_csi\_driver\_config](#input\_amazon\_eks\_aws\_ebs\_csi\_driver\_config) | configMap for AWS EBS CSI Driver add-on | `any` | `{}` | no |
-| <a name="input_amazon_eks_coredns_config"></a> [amazon\_eks\_coredns\_config](#input\_amazon\_eks\_coredns\_config) | Configuration for Amazon CoreDNS EKS add-on | `any` | `{}` | no |
-| <a name="input_amazon_eks_kube_proxy_config"></a> [amazon\_eks\_kube\_proxy\_config](#input\_amazon\_eks\_kube\_proxy\_config) | ConfigMap for Amazon EKS Kube-Proxy add-on | `any` | `{}` | no |
 | <a name="input_aws_account"></a> [aws\_account](#input\_aws\_account) | n/a | `string` | `""` | no |
 | <a name="input_aws_admin_usernames"></a> [aws\_admin\_usernames](#input\_aws\_admin\_usernames) | A list of one or more AWS usernames with authorized access to KMS and EKS resources, will automatically add the user running the terraform as an admin | `list(string)` | `[]` | no |
 | <a name="input_aws_auth_users"></a> [aws\_auth\_users](#input\_aws\_auth\_users) | List of map of users to add to aws-auth configmap | <pre>list(object({<br>    userarn  = string<br>    username = string<br>    groups   = list(string)<br>  }))</pre> | `[]` | no |
@@ -77,8 +75,6 @@ To view examples for how you can leverage this EKS Module, please see the [examp
 | <a name="input_eks_managed_node_group_defaults"></a> [eks\_managed\_node\_group\_defaults](#input\_eks\_managed\_node\_group\_defaults) | Map of EKS-managed node group default configurations | `any` | `{}` | no |
 | <a name="input_eks_managed_node_groups"></a> [eks\_managed\_node\_groups](#input\_eks\_managed\_node\_groups) | Managed node groups configuration | `any` | `{}` | no |
 | <a name="input_enable_amazon_eks_aws_ebs_csi_driver"></a> [enable\_amazon\_eks\_aws\_ebs\_csi\_driver](#input\_enable\_amazon\_eks\_aws\_ebs\_csi\_driver) | Enable EKS Managed AWS EBS CSI Driver add-on; enable\_amazon\_eks\_aws\_ebs\_csi\_driver and enable\_self\_managed\_aws\_ebs\_csi\_driver are mutually exclusive | `bool` | `false` | no |
-| <a name="input_enable_amazon_eks_coredns"></a> [enable\_amazon\_eks\_coredns](#input\_enable\_amazon\_eks\_coredns) | Enable Amazon EKS CoreDNS add-on | `bool` | `false` | no |
-| <a name="input_enable_amazon_eks_kube_proxy"></a> [enable\_amazon\_eks\_kube\_proxy](#input\_enable\_amazon\_eks\_kube\_proxy) | Enable Kube Proxy add-on | `bool` | `false` | no |
 | <a name="input_enable_aws_node_termination_handler"></a> [enable\_aws\_node\_termination\_handler](#input\_enable\_aws\_node\_termination\_handler) | Enable AWS Node Termination Handler add-on | `bool` | `false` | no |
 | <a name="input_enable_calico"></a> [enable\_calico](#input\_enable\_calico) | Enable Calico add-on | `bool` | `false` | no |
 | <a name="input_enable_cluster_autoscaler"></a> [enable\_cluster\_autoscaler](#input\_enable\_cluster\_autoscaler) | Enable Cluster autoscaler add-on | `bool` | `false` | no |

--- a/modules/eks/eks-addons.tf
+++ b/modules/eks/eks-addons.tf
@@ -7,7 +7,7 @@ locals {
 }
 
 module "eks_blueprints_kubernetes_addons" {
-  source = "git::https://github.com/aws-ia/terraform-aws-eks-blueprints.git//modules/kubernetes-addons?ref=v4.27.0"
+  source = "git::https://github.com/aws-ia/terraform-aws-eks-blueprints.git//modules/kubernetes-addons?ref=v4.29.0"
 
   eks_cluster_id       = module.aws_eks.cluster_name
   eks_cluster_endpoint = module.aws_eks.cluster_endpoint
@@ -18,14 +18,6 @@ module "eks_blueprints_kubernetes_addons" {
   auto_scaling_group_names = local.self_managed_node_group_names
 
   # blueprints addons
-
-  # EKS CoreDNS
-  enable_amazon_eks_coredns = var.enable_amazon_eks_coredns
-  amazon_eks_coredns_config = var.amazon_eks_coredns_config
-
-  # EKS kube-proxy
-  enable_amazon_eks_kube_proxy = var.enable_amazon_eks_kube_proxy
-  amazon_eks_kube_proxy_config = var.amazon_eks_kube_proxy_config
 
   # EKS EBS CSI Driver
   enable_amazon_eks_aws_ebs_csi_driver = var.enable_amazon_eks_aws_ebs_csi_driver

--- a/modules/eks/variables.tf
+++ b/modules/eks/variables.tf
@@ -186,32 +186,6 @@ EOD
   default     = {}
 }
 
-#----------------AWS CoreDNS-------------------------
-variable "enable_amazon_eks_coredns" {
-  description = "Enable Amazon EKS CoreDNS add-on"
-  type        = bool
-  default     = false
-}
-
-variable "amazon_eks_coredns_config" {
-  description = "Configuration for Amazon CoreDNS EKS add-on"
-  type        = any
-  default     = {}
-}
-
-#----------------AWS Kube Proxy-------------------------
-variable "enable_amazon_eks_kube_proxy" {
-  description = "Enable Kube Proxy add-on"
-  type        = bool
-  default     = false
-}
-
-variable "amazon_eks_kube_proxy_config" {
-  description = "ConfigMap for Amazon EKS Kube-Proxy add-on"
-  type        = any
-  default     = {}
-}
-
 #----------------AWS EBS CSI Driver-------------------------
 variable "enable_amazon_eks_aws_ebs_csi_driver" {
   description = "Enable EKS Managed AWS EBS CSI Driver add-on; enable_amazon_eks_aws_ebs_csi_driver and enable_self_managed_aws_ebs_csi_driver are mutually exclusive"


### PR DESCRIPTION
This PR pins versions to addons that are not managed by AWS & uses most_recent for AWS managed addons, as well as, re-enables node termination handler

closes #180 