### PR TITLE
add conditional for zipmap function

### DIFF
--- a/modules/eks/k8s-manifests.tf
+++ b/modules/eks/k8s-manifests.tf
@@ -3,7 +3,7 @@
 #################################################################################
 
 resource "kubectl_manifest" "eni_config" {
-  for_each = length(var.vpc_cni_custom_subnet == 0) ? {} : zipmap(local.azs, var.vpc_cni_custom_subnet)
+  for_each = length(var.vpc_cni_custom_subnet) == 0 ? {} : zipmap(local.azs, var.vpc_cni_custom_subnet)
 
   yaml_body = yamlencode({
     apiVersion = "crd.k8s.amazonaws.com/v1alpha1"

--- a/modules/eks/k8s-manifests.tf
+++ b/modules/eks/k8s-manifests.tf
@@ -3,7 +3,7 @@
 #################################################################################
 
 resource "kubectl_manifest" "eni_config" {
-  for_each = zipmap(local.azs, var.vpc_cni_custom_subnet)
+  for_each = length(var.vpc_cni_custom_subnet) == length(local.azs) ? zipmap(local.azs, var.vpc_cni_custom_subnet) : {}
 
   yaml_body = yamlencode({
     apiVersion = "crd.k8s.amazonaws.com/v1alpha1"

--- a/modules/eks/k8s-manifests.tf
+++ b/modules/eks/k8s-manifests.tf
@@ -3,7 +3,7 @@
 #################################################################################
 
 resource "kubectl_manifest" "eni_config" {
-  for_each = length(var.vpc_cni_custom_subnet) == length(local.azs) ? zipmap(local.azs, var.vpc_cni_custom_subnet) : {}
+  for_each = length(var.vpc_cni_custom_subnet == 0) ? {} : zipmap(local.azs, var.vpc_cni_custom_subnet)
 
   yaml_body = yamlencode({
     apiVersion = "crd.k8s.amazonaws.com/v1alpha1"
@@ -16,4 +16,11 @@ resource "kubectl_manifest" "eni_config" {
       subnet         = each.value
     }
   })
+
+  lifecycle {
+    precondition {
+      condition     = length(var.vpc_cni_custom_subnet) == length(local.azs) || length(var.vpc_cni_custom_subnet) == 0
+      error_message = "the number of items in var.vpc_cni_custom_subnet must match the number of items in local.azs"
+    }
+  }
 }


### PR DESCRIPTION
fixes #208 

[zipmap](https://developer.hashicorp.com/terraform/language/functions/zipmap) requires that the two lists are the same length


> zipmap constructs a map from a list of keys and a corresponding list of values.
> 
> ```zipmap(keyslist, valueslist)```
> 
> Both **keyslist and valueslist must be of the same length**. keyslist must be a list of strings, while valueslist can be a list of any type.
