### PR TITLE
Configure Renovate (Supersedes #1)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,3 +52,7 @@ repos:
 #      - id: terraform_tflint
 #      - id: terraform_tfsec
 #      - id: terraform_validate
+  - repo: https://github.com/renovatebot/pre-commit-hooks
+    rev: 35.66.3
+    hooks:
+      - id: renovate-config-validator

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,36 @@
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  extends: [
+    // Tells Renovate to maintain one GitHub issue as the "dependency dashboard". See https://docs.renovatebot.com/key-concepts/dashboard
+    ":dependencyDashboard",
+    // Use semantic commit type fix for dependencies and chore for all others if semantic commits are in use. See https://docs.renovatebot.com/presets-default/#semanticprefixfixdepschoreothers
+    ":semanticPrefixFixDepsChoreOthers",
+    // Ignore node_modules, bower_components, vendor and various test/tests directories. See https://docs.renovatebot.com/presets-default/#ignoremodulesandtests
+    ":ignoreModulesAndTests",
+    // Group all updates together. See https://docs.renovatebot.com/presets-group/#groupall
+    // Other less drastic groupings that may be of interest include: group:allNonMajor, group:recommended, group:monorepos
+    "group:all",
+    // Apply crowd-sourced package replacement rules. See https://docs.renovatebot.com/presets-replacements/#replacementsall
+    "replacements:all",
+    // Apply crowd-sourced workarounds for known problems with packages. See https://docs.renovatebot.com/presets-workarounds/#workaroundsall
+    "workarounds:all",
+    // Only run outside of office hours. See https://docs.renovatebot.com/presets-schedule/#schedulenonofficehours
+    "schedule:nonOfficeHours"
+  ],
+  // Labels to set in Pull Request. See https://docs.renovatebot.com/configuration-options/#labels
+  labels: [
+    "renovate"
+  ],
+  // Rate limit PRs to maximum x created per hour. 0 means no limit. See https://docs.renovatebot.com/configuration-options/#prhourlylimit
+  prHourlyLimit: 0,
+  // Limit to a maximum of x concurrent branches/PRs. 0 means no limit. See https://docs.renovatebot.com/configuration-options/#prconcurrentlimit
+  prConcurrentLimit: 0,
+  // List of additional notes/templates to include in the Pull Request body. See https://docs.renovatebot.com/configuration-options/#prbodynotes
+  prBodyNotes: [
+    "- :warning: The E2E tests need to be run, they have a manual trigger. To start them add a comment to this PR that says `/test all`"
+  ],
+  // Enable updates to the pre-commit-config.yaml file. See https://docs.renovatebot.com/modules/manager/pre-commit/
+  "pre-commit": {
+    enabled: true
+  }
+}


### PR DESCRIPTION
Configure Renovate. Supersedes PR #1 

Initial design is to make Renovate as "quiet" as possible. With this configuration Renovate will batch all changes into 1 PR, and will only open or update PRs outside of normal office hours.