### PR TITLE
Renovate updates

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,11 +1,18 @@
+# renovate: datasource=github-tags depName=npryce/adr-tools
 adr-tools 3.0.0
 awscli 2.11.16
+# renovate: datasource=github-tags depName=bridgecrewio/checkov
 checkov 2.3.3
 golang 1.20.3
+# renovate: datasource=github-tags depName=golangci/golangci-lint
 golangci-lint 1.50.1
+make 4.4
+# renovate: datasource=github-tags depName=pre-commit/pre-commit
 pre-commit 3.0.1
 terraform 1.4.6
+# renovate: datasource=github-tags depName=terraform-docs/terraform-docs
 terraform-docs 0.16.0
+# renovate: datasource=github-tags depName=terraform-linters/tflint
 tflint 0.44.1
+# renovate: datasource=github-tags depName=aquasecurity/tfsec
 tfsec 1.28.1
-make 4.4

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 # The version of the build harness container to use
 BUILD_HARNESS_REPO := ghcr.io/defenseunicorns/not-a-build-harness/not-a-build-harness
+# renovate: datasource=docker depName=ghcr.io/defenseunicorns/not-a-build-harness/not-a-build-harness versioning=docker
 BUILD_HARNESS_VERSION := 0.0.13
 
 .DEFAULT_GOAL := help

--- a/renovate.json5
+++ b/renovate.json5
@@ -34,6 +34,15 @@
     enabled: true
   },
   "regexManagers": [
+    // Custom regex manager for the Makefile that follows the pattern documented here: https://docs.renovatebot.com/modules/manager/regex/#advanced-capture
+    {
+      "fileMatch": ["^Makefile"],
+      "matchStrings": [
+        "datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s.*?_VERSION := (?<currentValue>.*)\\s"
+      ],
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver-coerced{{/if}}",
+      "extractVersionTemplate": "^v?(?<version>.*)$"
+    },
     // Custom regex manager for the .tool-versions file that follows the pattern documented here: https://docs.renovatebot.com/modules/manager/regex/#advanced-capture
     {
       "fileMatch": ["^.tool-versions$"],

--- a/renovate.json5
+++ b/renovate.json5
@@ -32,5 +32,16 @@
   // Enable updates to the pre-commit-config.yaml file. See https://docs.renovatebot.com/modules/manager/pre-commit/
   "pre-commit": {
     enabled: true
-  }
+  },
+  "regexManagers": [
+    // Custom regex manager for the .tool-versions file that follows the pattern documented here: https://docs.renovatebot.com/modules/manager/regex/#advanced-capture
+    {
+      "fileMatch": ["^.tool-versions$"],
+      "matchStrings": [
+        "datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s.*? (?<currentValue>.*)\\s"
+      ],
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver-coerced{{/if}}",
+      "extractVersionTemplate": "^v?(?<version>.*)$"
+    }
+  ]
 }

--- a/renovate.json5
+++ b/renovate.json5
@@ -13,9 +13,7 @@
     // Apply crowd-sourced package replacement rules. See https://docs.renovatebot.com/presets-replacements/#replacementsall
     "replacements:all",
     // Apply crowd-sourced workarounds for known problems with packages. See https://docs.renovatebot.com/presets-workarounds/#workaroundsall
-    "workarounds:all",
-    // Only run outside of office hours. See https://docs.renovatebot.com/presets-schedule/#schedulenonofficehours
-    "schedule:nonOfficeHours"
+    "workarounds:all"
   ],
   // Labels to set in Pull Request. See https://docs.renovatebot.com/configuration-options/#labels
   labels: [


### PR DESCRIPTION
Tested [here](https://github.com/RothAndrew/not-a-build-harness/pull/2)

Until https://github.com/renovatebot/renovate/pull/21942 is merged we will use a RegexManager for the ASDF plugins that aren't supported by Renovate yet.