### PR TITLE
export cloudinit_config vars for add_user_data

### DIFF
--- a/modules/bastion/templates/user_data.sh.tpl
+++ b/modules/bastion/templates/user_data.sh.tpl
@@ -334,5 +334,9 @@ _EOF_
 
 sudo service sshd restart
 
+# Export ssh_user and zarf_version for use in additional user-data script
+export ssh_user=${ssh_user}
+export zarf_version=${zarf_version}
+
 # Append addition user-data script
 ${additional_user_data_script}


### PR DESCRIPTION
the variables being set in the `cloudinit_config` for the user_data.sh.tpl are not being passed on to `additional_user_data_scripts`. 

adding export commands for `ssh_user` and `zarf_version` to be used in `additional_user_data_scripts` being defined in root modules.