### PR TITLE
Fix for renovate picking the wrong version for client-go

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -50,5 +50,11 @@
       "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver-coerced{{/if}}",
       "extractVersionTemplate": "^v?(?<version>.*)$"
     }
+  ],
+  packageRules: [
+    {
+      matchPackageNames: ["k8s.io/client-go"],
+      allowedVersions: "<1.0.0"
+    }
   ]
 }


### PR DESCRIPTION
See [here](https://github.com/renovatebot/renovate/issues/13012) and [here](https://github.com/kubernetes/client-go)