### PR TITLE
Switch from not-a-build-harness to build-harness

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
-BUILD_HARNESS_REPO=ghcr.io/defenseunicorns/not-a-build-harness/not-a-build-harness
-# renovate: datasource=docker depName=ghcr.io/defenseunicorns/not-a-build-harness/not-a-build-harness versioning=docker
-BUILD_HARNESS_VERSION=0.0.30
+BUILD_HARNESS_REPO=ghcr.io/defenseunicorns/build-harness/build-harness
+# renovate: datasource=docker depName=ghcr.io/defenseunicorns/build-harness/build-harness versioning=docker
+BUILD_HARNESS_VERSION=1.1.0

--- a/Makefile
+++ b/Makefile
@@ -101,15 +101,15 @@ bastion-connect: _create-folders ## To be used after deploying "secure mode" of 
 
 .PHONY: test
 test: ## Run all automated tests. Requires access to an AWS account. Costs real money.
-	$(MAKE) _test-all EXTRA_TEST_ARGS="-timeout 2h"
+	$(MAKE) _test-all EXTRA_TEST_ARGS="-timeout 3h"
 
 .PHONY: test-complete-insecure
 test-complete-insecure: ## Run one test (TestExamplesCompleteInsecure). Requires access to an AWS account. Costs real money.
-	$(MAKE) _test-all EXTRA_TEST_ARGS="-timeout 2h -run TestExamplesCompleteInsecure"
+	$(MAKE) _test-all EXTRA_TEST_ARGS="-timeout 3h -run TestExamplesCompleteInsecure"
 
 .PHONY: test-complete-secure
 test-complete-secure: ## Run one test (TestExamplesCompleteSecure). Requires access to an AWS account. Costs real money.
-	$(MAKE) _test-all EXTRA_TEST_ARGS="-timeout 2h -run TestExamplesCompleteSecure"
+	$(MAKE) _test-all EXTRA_TEST_ARGS="-timeout 3h -run TestExamplesCompleteSecure"
 
 .PHONY: docker-save-build-harness
 docker-save-build-harness: _create-folders ## Pulls the build harness docker image and saves it to a tarball

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -48,7 +48,7 @@ ip-10-200-48-31.us-east-2.compute.internal    Ready    <none>   22h   v1.23.16-e
 
 To do this manually, you're going to want to run:
 
-> NOTE: This is not really recommended. Better to use the make target / docker container. If the container doesn't have a tool you need, open an issue [here](https://github.com/defenseunicorns/not-a-build-harness) and we'll get it added.
+> NOTE: This is not really recommended. Better to use the make target / docker container. If the container doesn't have a tool you need, open an issue [here](https://github.com/defenseunicorns/build-harness) and we'll get it added.
 
 ```shell
 # Switch to the examples/complete directory

--- a/test/e2e/examples_complete_insecure_test.go
+++ b/test/e2e/examples_complete_insecure_test.go
@@ -22,6 +22,7 @@ func TestExamplesCompleteInsecure(t *testing.T) {
 		},
 		RetryableTerraformErrors: map[string]string{
 			".*empty output.*": "bug in aws_s3_bucket_logging, intermittent error",
+			".*timeout while waiting for state to become 'ACTIVE'.*": "Sometimes the EKS cluster takes a long time to create",
 		},
 		MaxRetries:         5,
 		TimeBetweenRetries: 5 * time.Second,

--- a/test/e2e/examples_complete_secure_test.go
+++ b/test/e2e/examples_complete_secure_test.go
@@ -39,6 +39,7 @@ func TestExamplesCompleteSecure(t *testing.T) {
 		},
 		RetryableTerraformErrors: map[string]string{
 			".*empty output.*": "bug in aws_s3_bucket_logging, intermittent error",
+			".*timeout while waiting for state to become 'ACTIVE'.*": "Sometimes the EKS cluster takes a long time to create",
 		},
 		MaxRetries:         5,
 		TimeBetweenRetries: 5 * time.Second,
@@ -55,6 +56,7 @@ func TestExamplesCompleteSecure(t *testing.T) {
 		},
 		RetryableTerraformErrors: map[string]string{
 			".*empty output.*": "bug in aws_s3_bucket_logging, intermittent error",
+			".*timeout while waiting for state to become 'ACTIVE'.*": "Sometimes the EKS cluster takes a long time to create",
 		},
 		MaxRetries:         5,
 		TimeBetweenRetries: 5 * time.Second,
@@ -70,6 +72,7 @@ func TestExamplesCompleteSecure(t *testing.T) {
 		},
 		RetryableTerraformErrors: map[string]string{
 			".*empty output.*": "bug in aws_s3_bucket_logging, intermittent error",
+			".*timeout while waiting for state to become 'ACTIVE'.*": "Sometimes the EKS cluster takes a long time to create",
 		},
 		MaxRetries:         5,
 		TimeBetweenRetries: 5 * time.Second,


### PR DESCRIPTION
Also increase the test timeout to 3 hours and add another retryable error. Previous tests ran into an issue with the EKS cluster taking longer than the 30 minutes that Terraform lets it take, which was causing either a fatal at the 2 hour limit or causing terraform apply to fail. This should fix both of those issues by allowing for a retry and giving the test more time to complete if needed.