### PR TITLE
Add ability to use `/update all` in a comment to autoformat, commit, and push pre-commit changes

### DIFF
--- a/.github/workflows/slash-command-dispatch.yml
+++ b/.github/workflows/slash-command-dispatch.yml
@@ -3,7 +3,7 @@ on:
   issue_comment:
     types: [created]
 jobs:
-  slashCommandDispatch:
+  slashCommandDispatchTest:
     if: github.event.issue.pull_request && contains(github.event.comment.body, '/test')
     runs-on: ubuntu-latest
     steps:
@@ -12,5 +12,18 @@ jobs:
         with:
           token: ${{ secrets.PAT }}
           commands: test
+          permission: write
+          issue-type: pull-request
+
+
+  slashCommandDispatchUpdate:
+    if: github.event.issue.pull_request && contains(github.event.comment.body, '/update')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Slash Command Dispatch
+        uses: peter-evans/slash-command-dispatch@v3
+        with:
+          token: ${{ secrets.PAT }}
+          commands: update
           permission: write
           issue-type: pull-request

--- a/.github/workflows/update-command.yml
+++ b/.github/workflows/update-command.yml
@@ -1,0 +1,241 @@
+name: update
+on:
+  repository_dispatch:
+    types: [update-command]
+
+permissions:
+  id-token: write
+  contents: write
+
+defaults:
+  run:
+    # We need -e -o pipefail for consistency with GitHub Actions' default behavior
+    shell: bash -e -o pipefail {0}
+
+jobs:
+  # Parse the command so we can decide which tests to run. Examples: "/test all", "/test validate", "/test e2e"
+  # We can do as many of these as we want to get as granular as we want.
+  parse:
+    runs-on: ubuntu-latest
+    outputs:
+      run-ping: ${{ steps.parse.outputs.ping }}
+      run-autoformat: ${{ steps.parse.outputs.autoformat }}
+    steps:
+      - name: Parse Args
+        id: parse
+        env:
+          DEBUG: ${{ toJSON(github.event.client_payload.slash_command) }}
+          ARGS_V1: ${{ github.event.client_payload.slash_command.arg1 }}
+          ARGS_V2: ${{ github.event.client_payload.slash_command.args.unnamed.all }}
+          EVENT_NAME: ${{ github.event_name }}
+        shell: bash
+        run: |
+          ARGS="${ARGS_V1}${ARGS_V2}"
+          printf "Event name is %s\n" "$EVENT_NAME"
+          printf "Args are %s\n" "$ARGS"
+          printf "\n\nslash_command is %s\n\n" "$DEBUG"
+          COMMANDS=(PING AUTOFORMAT) #all options here
+          if printf "%s" "${ARGS^^}" | grep -qE '\bALL\b'; then
+            # "all" explicitly does not include "ping"
+            for cmd in "${COMMANDS[@]}"; do
+              [[ $cmd == "PING" ]] && ! { printf "%s" "${ARGS^^}" | grep -qE '\bPING\b'; } && continue
+              printf -v "$cmd" "true"
+            done
+          else
+            for cmd in "${COMMANDS[@]}"; do
+              if printf "%s" "${ARGS^^}" | grep -qE "\b${cmd}\b"; then
+                printf -v "$cmd" "true"
+              fi
+            done
+          fi
+          for out in "${COMMANDS[@]}"; do
+            printf "%s=%s\n" "${out,,}" "${!out:-false}" >> $GITHUB_OUTPUT
+            printf "%s=%s\n" "${out,,}" "${!out:-false}"
+          done
+
+  # Do a simple ping/pong status update to validate things are working
+  ping:
+    runs-on: ubuntu-latest
+    needs: parse
+    if: needs.parse.outputs.run-ping == 'true'
+    steps:
+      - name: Create URL to the run output
+        if: github.event_name == 'repository_dispatch'
+        id: vars
+        run: echo "run-url=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" >> $GITHUB_OUTPUT
+
+      # Will update the comment that triggered the /test comment and add the run-url
+      - name: Update comment
+        if: github.event_name == 'repository_dispatch'
+        uses: peter-evans/create-or-update-comment@v3
+        with:
+          token: ${{ secrets.PAT }}
+          repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
+          comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
+          body: |
+            :robot: [View pipeline run][1]
+
+            [1]: ${{ steps.vars.outputs.run-url }}
+
+      # Update GitHub status for dispatch events
+      - name: "Update GitHub Status for this ref"
+        uses: "docker://cloudposse/github-status-updater"
+        with:
+          args: "-action update_state -state success -ref ${{ github.event.client_payload.pull_request.head.sha }} -repo ${{ github.event.client_payload.github.payload.repository.name }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT }}
+          GITHUB_CONTEXT: "update / ping (${{ github.event_name }})"
+          GITHUB_DESCRIPTION: "pong"
+          GITHUB_TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref }}
+          GITHUB_OWNER: ${{ github.event.client_payload.github.payload.repository.owner.login }}
+
+  # Update generated content
+  autoformat:
+    runs-on: ubuntu-latest
+    needs: parse
+    if: needs.parse.outputs.run-autoformat == 'true'
+    steps:
+      # Update GitHub status for pending pipeline run
+      - name: "Update GitHub Status for pending"
+        if: github.event_name == 'repository_dispatch'
+        uses: docker://cloudposse/github-status-updater
+        with:
+          args: "-action update_state -state pending -ref ${{ env.REPO_SHA }} -repo ${{ env.REPO_NAME }}"
+        env:
+          REPO_SHA: ${{ github.event.client_payload.pull_request.head.sha || github.sha }}
+          REPO_NAME: ${{ github.event.client_payload.github.payload.repository.name || github.event.repository.name }}
+          GITHUB_TOKEN: ${{ secrets.PAT }}
+          GITHUB_CONTEXT: "update / autoformat (${{ github.event_name }})"
+          GITHUB_DESCRIPTION: "started by @${{ github.event.client_payload.github.actor || github.actor }}"
+          GITHUB_TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref || github.ref_name }}
+          GITHUB_OWNER: ${{ github.event.client_payload.github.payload.repository.owner.login || github.repository_owner }}
+
+      - name: Create URL to the run output
+        if: github.event_name == 'repository_dispatch'
+        id: vars
+        run: echo "run-url=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" >> $GITHUB_OUTPUT
+
+      # Will update the comment that triggered the /test comment and add the run-url
+      - name: Update comment
+        if: github.event_name == 'repository_dispatch'
+        uses: peter-evans/create-or-update-comment@v3
+        with:
+          token: ${{ secrets.PAT }}
+          repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
+          comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
+          body: |
+            :robot: [View pipeline run][1]
+
+            [1]: ${{ steps.vars.outputs.run-url }}
+
+      # Checkout the code from GitHub Pull Request
+      - name: "Checkout the code"
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.PAT }}
+          repository: ${{ github.event.client_payload.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event.client_payload.pull_request.head.ref || github.ref_name }}
+
+      - name: Init gopath cache
+        uses: actions/cache@v3
+        with:
+          path: "${{ github.workspace }}/.cache/go"
+          key: "gopath|${{ hashFiles('.tool-versions') }}|${{ hashFiles('go.sum') }}"
+
+      - name: Init gobuild cache
+        uses: actions/cache@v3
+        with:
+          path: "${{ github.workspace }}/.cache/go-build"
+          key: "gobuild|${{ hashFiles('.tool-versions') }}|${{ hashFiles('go.sum') }}"
+
+      - name: Init zarf cache
+        uses: actions/cache@v3
+        with:
+          path: "${{ github.workspace }}/.cache/.zarf-cache"
+          key: "zarf|${{ hashFiles('.tool-versions') }}"
+
+      - name: Init docker cache
+        id: init-docker-cache
+        uses: actions/cache@v3
+        with:
+          path: "${{ github.workspace }}/.cache/docker"
+          key: "docker|${{ hashFiles('.env') }}"
+
+      - name: Docker save build harness
+        if: steps.init-docker-cache.outputs.cache-hit != 'true'
+        run: |
+          make docker-save-build-harness
+
+      - name: Load build harness
+        run: |
+          make docker-load-build-harness
+
+      - name: Get Terraform version from .tool-versions
+        id: get_tf_version
+        run: echo "tf_version=$(grep 'terraform ' .tool-versions)" >> $GITHUB_OUTPUT
+
+      - name: Init Terraform Cache
+        uses: actions/cache@v3
+        with:
+          path: "${{ github.workspace }}/.cache/.terraform.d/plugin-cache"
+          key: "${{ runner.os }}-terraform-plugins|${{ steps.get_tf_version.outputs.tf_version }}|${{ hashFiles('examples/complete/providers.tf') }}"
+
+      - name: Update files with automatic formatting tools
+        run: |
+          # Make it always return 0 since changing files is considered a failure by pre-commit
+          make autoformat || true
+
+      - name: Commit and push changes
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          skip_checkout: true
+
+      # Update GitHub status for failing pipeline run
+      - name: "Update GitHub Status for failure"
+        if: ${{ failure() && github.event_name == 'repository_dispatch' }}
+        uses: docker://cloudposse/github-status-updater
+        with:
+          args: "-action update_state -state failure -ref ${{ env.REPO_SHA }} -repo ${{ env.REPO_NAME }}"
+        env:
+          REPO_SHA: ${{ github.event.client_payload.pull_request.head.sha || github.sha }}
+          REPO_NAME: ${{ github.event.client_payload.github.payload.repository.name || github.event.repository.name }}
+          GITHUB_TOKEN: ${{ secrets.PAT }}
+          GITHUB_CONTEXT: "update / autoformat (${{ github.event_name }})"
+          GITHUB_DESCRIPTION: "run failed"
+          GITHUB_TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref || github.ref_name }}
+          GITHUB_OWNER: ${{ github.event.client_payload.github.payload.repository.owner.login || github.repository_owner }}
+
+      # Update GitHub status for successful pipeline run
+      - name: "Update GitHub Status for success"
+        if: github.event_name == 'repository_dispatch'
+        uses: docker://cloudposse/github-status-updater
+        with:
+          args: "-action update_state -state success -ref ${{ env.REPO_SHA }} -repo ${{ env.REPO_NAME }}"
+        env:
+          REPO_SHA: ${{ github.event.client_payload.pull_request.head.sha || github.sha }}
+          REPO_NAME: ${{ github.event.client_payload.github.payload.repository.name || github.event.repository.name }}
+          GITHUB_TOKEN: ${{ secrets.PAT }}
+          GITHUB_CONTEXT: "update / autoformat (${{ github.event_name }})"
+          GITHUB_DESCRIPTION: "run passed"
+          GITHUB_TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref || github.ref_name }}
+          GITHUB_OWNER: ${{ github.event.client_payload.github.payload.repository.owner.login || github.repository_owner }}
+
+      # Update GitHub status for cancelled pipeline run
+      - name: "Update GitHub Status for cancelled"
+        if: ${{ cancelled() && github.event_name == 'repository_dispatch' }}
+        uses: docker://cloudposse/github-status-updater
+        with:
+          args: "-action update_state -state error -ref ${{ env.REPO_SHA }} -repo ${{ env.REPO_NAME }}"
+        env:
+          REPO_SHA: ${{ github.event.client_payload.pull_request.head.sha || github.sha }}
+          REPO_NAME: ${{ github.event.client_payload.github.payload.repository.name || github.event.repository.name }}
+          GITHUB_TOKEN: ${{ secrets.PAT }}
+          GITHUB_CONTEXT: "update / autoformat (${{ github.event_name }})"
+          GITHUB_DESCRIPTION: "run cancelled"
+          GITHUB_TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref || github.ref_name }}
+          GITHUB_OWNER: ${{ github.event.client_payload.github.payload.repository.owner.login || github.repository_owner }}

--- a/Makefile
+++ b/Makefile
@@ -166,3 +166,7 @@ pre-commit-common: ## Run the common pre-commit hooks. Returns nonzero exit code
 .PHONY: fix-cache-permissions
 fix-cache-permissions: ## Fixes the permissions on the pre-commit cache
 	docker run $(TTY_ARG) --rm -v "${PWD}:/app" --workdir "/app" -e "PRE_COMMIT_HOME=/app/.cache/pre-commit" ${BUILD_HARNESS_REPO}:${BUILD_HARNESS_VERSION} chmod -R a+rx .cache
+
+.PHONY: autoformat
+autoformat: ## Update files with automatic formatting tools. Uses Docker for maximum compatibility.
+	$(MAKE) _runhooks HOOK="" SKIP="check-added-large-files,check-merge-conflict,detect-aws-credentials,detect-private-key,check-yaml,golangci-lint,terraform_checkov,terraform_tflint,renovate-config-validator"


### PR DESCRIPTION
Usage:

1. Add a comment to a PR that says `/update all`
2. Profit

<img width="951" alt="image" src="https://github.com/defenseunicorns/delivery-aws-iac/assets/16000938/f7d8cecc-5f6b-49df-b212-d1e6955e06f8">

Tested here: https://github.com/RothAndrew/delivery-aws-iac/pull/1

Closes #283 