### PR TITLE
Fix Renovate schedule again

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -18,8 +18,7 @@
   // Giving a small window constrains when Renovate will create PRs. The objective here is to only have Renovate create PRs on weekdays in the morning. This setting only affects when PRs are created. Without other configuration Renovate will rebase any PRs that already exist whenever it wants to.
   // We need an "after" and a "before" because there is other automation that happens earlier that we don't want Renovate to conflict with.
   schedule: [
-    "after 7am every weekday",
-    "before 9am every weekday"
+    "after 7am and before 9am every weekday"
   ],
   // This will prevent Renovate from automatically rebasing PRs. Without this, Renovate will rebase PRs whenever it wants to. The 'schedule' param is only for creating PRs. Because we are grouping all changes into one PR without this Renovate will be constantly rebasing that PR which we don't want since every time that happens another set of GHA status checks are kicked off.
   // Using a value of "conflicted" means that Renovate will only rebase PRs if they are in a conflicted state. See https://docs.renovatebot.com/configuration-options/#rebasewhen


### PR DESCRIPTION
Turns out the array uses logical OR, so it actually needs to be this way if we want it to only run for that small window in the morning. See https://docs.renovatebot.com/configuration-options/#schedule