### PR TITLE
Include GovCloud in tests

### DIFF
--- a/.github/actions/comment/action.yml
+++ b/.github/actions/comment/action.yml
@@ -2,6 +2,11 @@ name: Update Slash Command Dispatch Comment
 
 description: Update Slash Command Dispatch comment with the run URL
 
+inputs:
+  token:
+    description: Personal Access Token (PAT) used to update the comment
+    required: true
+
 runs:
   using: composite
   steps:
@@ -15,7 +20,7 @@ runs:
       if: github.event_name == 'repository_dispatch'
       uses: peter-evans/create-or-update-comment@v3
       with:
-        token: ${{ secrets.PAT }}
+        token: ${{ inputs.token }}
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
         body: |

--- a/.github/actions/comment/action.yml
+++ b/.github/actions/comment/action.yml
@@ -1,0 +1,23 @@
+name: Update Slash Command Dispatch Comment
+
+description: Update Slash Command Dispatch comment with the run URL
+
+runs:
+  using: composite
+  steps:
+    - name: Create URL to the run output
+      id: vars
+      shell: bash -e -o pipefail {0}
+      run: echo "run-url=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" >> $GITHUB_OUTPUT
+
+    # Will update the comment that triggered the /test comment and add the run-url
+    - name: Update comment
+      if: github.event_name == 'repository_dispatch'
+      uses: peter-evans/create-or-update-comment@v3
+      with:
+        token: ${{ secrets.PAT }}
+        repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
+        comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
+        body: |
+          :robot: [View pipeline run][1]
+          [1]: ${{ steps.vars.outputs.run-url }}

--- a/.github/actions/e2e/action.yml
+++ b/.github/actions/e2e/action.yml
@@ -1,0 +1,154 @@
+name: Run E2E Tests
+
+description: Run E2E Tests
+
+inputs:
+  account:
+    description: The AWS account to use. Valid values are "commercial" or "govcloud"
+    required: true
+
+runs:
+  using: composite
+  steps:
+    # Update GitHub status for pending pipeline run
+    - name: "Update GitHub Status for pending"
+      if: github.event_name == 'repository_dispatch'
+      uses: docker://cloudposse/github-status-updater
+      with:
+        args: "-action update_state -state pending -ref ${{ env.REPO_SHA }} -repo ${{ env.REPO_NAME }}"
+      env:
+        REPO_SHA: ${{ github.event.client_payload.pull_request.head.sha || github.sha }}
+        REPO_NAME: ${{ github.event.client_payload.github.payload.repository.name || github.event.repository.name }}
+        GITHUB_TOKEN: ${{ secrets.PAT }}
+        GITHUB_CONTEXT: "e2e / ${{inputs.account}}"
+        GITHUB_DESCRIPTION: "started by @${{ github.event.client_payload.github.actor || github.actor }}"
+        GITHUB_TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref || github.ref_name }}
+        GITHUB_OWNER: ${{ github.event.client_payload.github.payload.repository.owner.login || github.repository_owner }}
+
+    # Checkout the code from GitHub Pull Request
+    - name: "Checkout the code"
+      uses: actions/checkout@v3
+      with:
+        token: ${{ secrets.PAT }}
+        repository: ${{ github.event.client_payload.pull_request.head.repo.full_name || github.repository }}
+        ref: ${{ github.event.client_payload.pull_request.head.ref || github.ref_name }}
+
+    - name: Init gopath cache
+      uses: actions/cache@v3
+      with:
+        path: "${{ github.workspace }}/.cache/go"
+        key: "gopath|${{ hashFiles('.tool-versions') }}|${{ hashFiles('go.sum') }}"
+
+    - name: Init gobuild cache
+      uses: actions/cache@v3
+      with:
+        path: "${{ github.workspace }}/.cache/go-build"
+        key: "gobuild|${{ hashFiles('.tool-versions') }}|${{ hashFiles('go.sum') }}"
+
+    - name: Init zarf cache
+      uses: actions/cache@v3
+      with:
+        path: "${{ github.workspace }}/.cache/.zarf-cache"
+        key: "zarf|${{ hashFiles('.tool-versions') }}"
+
+    - name: Init docker cache
+      id: init-docker-cache
+      uses: actions/cache@v3
+      with:
+        path: "${{ github.workspace }}/.cache/docker"
+        key: "docker|${{ hashFiles('.env') }}"
+
+    - name: Docker save build harness
+      if: steps.init-docker-cache.outputs.cache-hit != 'true'
+      run: |
+        make docker-save-build-harness
+
+    - name: Load build harness
+      run: |
+        make docker-load-build-harness
+
+    - name: Get Terraform version from .tool-versions
+      id: get_tf_version
+      run: echo "tf_version=$(grep 'terraform ' .tool-versions)" >> $GITHUB_OUTPUT
+
+    - name: Init Terraform Cache
+      uses: actions/cache@v3
+      with:
+        path: "${{ github.workspace }}/.cache/.terraform.d/plugin-cache"
+        key: "${{ runner.os }}-terraform-plugins|${{ steps.get_tf_version.outputs.tf_version }}|${{ hashFiles('examples/complete/providers.tf') }}"
+
+    - name: Configure AWS Credentials for Commercial
+      if: ${{ inputs.account == 'commercial' }}
+      uses: aws-actions/configure-aws-credentials@v2
+      with:
+        role-to-assume: ${{ secrets.AWS_COMMERCIAL_ROLE_TO_ASSUME }}
+        role-session-name: ${{ github.event.client_payload.pull_request.head.sha || github.sha }}
+        aws-region: us-east-1
+        # 21600 seconds == 6 hours
+        role-duration-seconds: 21600
+
+    - name: Configure AWS Credentials for GovCloud
+      if: ${{ inputs.account == 'govcloud' }}
+      uses: aws-actions/configure-aws-credentials@v2
+      with:
+        role-to-assume: ${{ secrets.AWS_GOVCLOUD_ROLE_TO_ASSUME }}
+        role-session-name: ${{ github.event.client_payload.pull_request.head.sha || github.sha }}
+        aws-region: us-east-1
+        # 21600 seconds == 6 hours
+        role-duration-seconds: 21600
+
+    - name: "Run E2E tests"
+      env:
+        REPO_URL: https://github.com/${{ github.repository }}.git
+        GIT_BRANCH: ${{ github.event.client_payload.pull_request.head.ref || github.ref_name }}
+      run: |
+        make test fix-cache-permissions
+
+    # Update GitHub status for successful pipeline run
+    - name: "Update GitHub Status for success"
+      if: ${{ success() && github.event_name == 'repository_dispatch' }}
+      uses: docker://cloudposse/github-status-updater
+      with:
+        args: "-action update_state -state success -ref ${{ env.REPO_SHA }} -repo ${{ env.REPO_NAME }}"
+      env:
+        REPO_SHA: ${{ github.event.client_payload.pull_request.head.sha || github.sha }}
+        REPO_NAME: ${{ github.event.client_payload.github.payload.repository.name || github.event.repository.name }}
+        GITHUB_TOKEN: ${{ secrets.PAT }}
+        GITHUB_CONTEXT: "e2e / ${{inputs.account}}"
+        GITHUB_DESCRIPTION: "run passed"
+        GITHUB_TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref || github.ref_name }}
+        GITHUB_OWNER: ${{ github.event.client_payload.github.payload.repository.owner.login || github.repository_owner }}
+
+    # Update GitHub status for failing pipeline run
+    - name: "Update GitHub Status for failure"
+      if: ${{ failure() && github.event_name == 'repository_dispatch' }}
+      uses: docker://cloudposse/github-status-updater
+      with:
+        args: "-action update_state -state failure -ref ${{ env.REPO_SHA }} -repo ${{ env.REPO_NAME }}"
+      env:
+        REPO_SHA: ${{ github.event.client_payload.pull_request.head.sha || github.sha }}
+        REPO_NAME: ${{ github.event.client_payload.github.payload.repository.name || github.event.repository.name }}
+        GITHUB_TOKEN: ${{ secrets.PAT }}
+        GITHUB_CONTEXT: "e2e / ${{inputs.account}}"
+        GITHUB_DESCRIPTION: "run failed"
+        GITHUB_TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref || github.ref_name }}
+        GITHUB_OWNER: ${{ github.event.client_payload.github.payload.repository.owner.login || github.repository_owner }}
+
+    # Update GitHub status for cancelled pipeline run
+    - name: "Update GitHub Status for cancelled"
+      if: ${{ cancelled() && github.event_name == 'repository_dispatch' }}
+      uses: docker://cloudposse/github-status-updater
+      with:
+        args: "-action update_state -state error -ref ${{ env.REPO_SHA }} -repo ${{ env.REPO_NAME }}"
+      env:
+        REPO_SHA: ${{ github.event.client_payload.pull_request.head.sha || github.sha }}
+        REPO_NAME: ${{ github.event.client_payload.github.payload.repository.name || github.event.repository.name }}
+        GITHUB_TOKEN: ${{ secrets.PAT }}
+        GITHUB_CONTEXT: "e2e / ${{inputs.account}}"
+        GITHUB_DESCRIPTION: "run cancelled"
+        GITHUB_TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref || github.ref_name }}
+        GITHUB_OWNER: ${{ github.event.client_payload.github.payload.repository.owner.login || github.repository_owner }}

--- a/.github/actions/e2e/action.yml
+++ b/.github/actions/e2e/action.yml
@@ -3,8 +3,14 @@ name: Run E2E Tests
 description: Run E2E Tests
 
 inputs:
+  token:
+    description: Personal Access Token (PAT) used to update the comment
+    required: true
   account:
     description: The AWS account to use. Valid values are "commercial" or "govcloud"
+    required: true
+  role-to-assume:
+    description: The AWS IAM Role to assume in the target account
     required: true
 
 runs:
@@ -19,7 +25,7 @@ runs:
       env:
         REPO_SHA: ${{ github.event.client_payload.pull_request.head.sha || github.sha }}
         REPO_NAME: ${{ github.event.client_payload.github.payload.repository.name || github.event.repository.name }}
-        GITHUB_TOKEN: ${{ secrets.PAT }}
+        GITHUB_TOKEN: ${{ inputs.token }}
         GITHUB_CONTEXT: "e2e / ${{inputs.account}}"
         GITHUB_DESCRIPTION: "started by @${{ github.event.client_payload.github.actor || github.actor }}"
         GITHUB_TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
@@ -30,7 +36,7 @@ runs:
     - name: "Checkout the code"
       uses: actions/checkout@v3
       with:
-        token: ${{ secrets.PAT }}
+        token: ${{ inputs.token }}
         repository: ${{ github.event.client_payload.pull_request.head.repo.full_name || github.repository }}
         ref: ${{ github.event.client_payload.pull_request.head.ref || github.ref_name }}
 
@@ -85,7 +91,7 @@ runs:
       if: ${{ inputs.account == 'commercial' }}
       uses: aws-actions/configure-aws-credentials@v2
       with:
-        role-to-assume: ${{ secrets.AWS_COMMERCIAL_ROLE_TO_ASSUME }}
+        role-to-assume: ${{ inputs.role-to-assume }}
         role-session-name: ${{ github.event.client_payload.pull_request.head.sha || github.sha }}
         aws-region: us-east-1
         # 21600 seconds == 6 hours
@@ -95,7 +101,7 @@ runs:
       if: ${{ inputs.account == 'govcloud' }}
       uses: aws-actions/configure-aws-credentials@v2
       with:
-        role-to-assume: ${{ secrets.AWS_GOVCLOUD_ROLE_TO_ASSUME }}
+        role-to-assume: ${{ inputs.role-to-assume }}
         role-session-name: ${{ github.event.client_payload.pull_request.head.sha || github.sha }}
         aws-region: us-east-1
         # 21600 seconds == 6 hours
@@ -115,7 +121,7 @@ runs:
       env:
         REPO_SHA: ${{ github.event.client_payload.pull_request.head.sha || github.sha }}
         REPO_NAME: ${{ github.event.client_payload.github.payload.repository.name || github.event.repository.name }}
-        GITHUB_TOKEN: ${{ secrets.PAT }}
+        GITHUB_TOKEN: ${{ inputs.token }}
         GITHUB_CONTEXT: "e2e / ${{inputs.account}}"
         GITHUB_DESCRIPTION: "run passed"
         GITHUB_TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
@@ -131,7 +137,7 @@ runs:
       env:
         REPO_SHA: ${{ github.event.client_payload.pull_request.head.sha || github.sha }}
         REPO_NAME: ${{ github.event.client_payload.github.payload.repository.name || github.event.repository.name }}
-        GITHUB_TOKEN: ${{ secrets.PAT }}
+        GITHUB_TOKEN: ${{ inputs.token }}
         GITHUB_CONTEXT: "e2e / ${{inputs.account}}"
         GITHUB_DESCRIPTION: "run failed"
         GITHUB_TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
@@ -147,7 +153,7 @@ runs:
       env:
         REPO_SHA: ${{ github.event.client_payload.pull_request.head.sha || github.sha }}
         REPO_NAME: ${{ github.event.client_payload.github.payload.repository.name || github.event.repository.name }}
-        GITHUB_TOKEN: ${{ secrets.PAT }}
+        GITHUB_TOKEN: ${{ inputs.token }}
         GITHUB_CONTEXT: "e2e / ${{inputs.account}}"
         GITHUB_DESCRIPTION: "run cancelled"
         GITHUB_TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/actions/e2e/action.yml
+++ b/.github/actions/e2e/action.yml
@@ -6,8 +6,8 @@ inputs:
   token:
     description: Personal Access Token (PAT) used to update the comment
     required: true
-  account:
-    description: The AWS account to use. Valid values are "commercial" or "govcloud"
+  region:
+    description: Initial region to use for retrieving credentials
     required: true
   role-to-assume:
     description: The AWS IAM Role to assume in the target account
@@ -26,7 +26,7 @@ runs:
         REPO_SHA: ${{ github.event.client_payload.pull_request.head.sha || github.sha }}
         REPO_NAME: ${{ github.event.client_payload.github.payload.repository.name || github.event.repository.name }}
         GITHUB_TOKEN: ${{ inputs.token }}
-        GITHUB_CONTEXT: "e2e / ${{inputs.account}}"
+        GITHUB_CONTEXT: "e2e / ${{inputs.region}}"
         GITHUB_DESCRIPTION: "started by @${{ github.event.client_payload.github.actor || github.actor }}"
         GITHUB_TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
         GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref || github.ref_name }}
@@ -80,22 +80,11 @@ runs:
         key: "${{ runner.os }}-terraform-plugins|${{ steps.get_tf_version.outputs.tf_version }}|${{ hashFiles('examples/complete/providers.tf') }}"
 
     - name: Configure AWS Credentials for Commercial
-      if: ${{ inputs.account == 'commercial' }}
       uses: aws-actions/configure-aws-credentials@v2
       with:
         role-to-assume: ${{ inputs.role-to-assume }}
         role-session-name: ${{ github.event.client_payload.pull_request.head.sha || github.sha }}
-        aws-region: us-east-1
-        # 21600 seconds == 6 hours
-        role-duration-seconds: 21600
-
-    - name: Configure AWS Credentials for GovCloud
-      if: ${{ inputs.account == 'govcloud' }}
-      uses: aws-actions/configure-aws-credentials@v2
-      with:
-        role-to-assume: ${{ inputs.role-to-assume }}
-        role-session-name: ${{ github.event.client_payload.pull_request.head.sha || github.sha }}
-        aws-region: us-east-1
+        aws-region: ${{ inputs.region }}
         # 21600 seconds == 6 hours
         role-duration-seconds: 21600
 
@@ -114,7 +103,7 @@ runs:
         REPO_SHA: ${{ github.event.client_payload.pull_request.head.sha || github.sha }}
         REPO_NAME: ${{ github.event.client_payload.github.payload.repository.name || github.event.repository.name }}
         GITHUB_TOKEN: ${{ inputs.token }}
-        GITHUB_CONTEXT: "e2e / ${{inputs.account}}"
+        GITHUB_CONTEXT: "e2e / ${{inputs.region}}"
         GITHUB_DESCRIPTION: "run passed"
         GITHUB_TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
         GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref || github.ref_name }}
@@ -130,7 +119,7 @@ runs:
         REPO_SHA: ${{ github.event.client_payload.pull_request.head.sha || github.sha }}
         REPO_NAME: ${{ github.event.client_payload.github.payload.repository.name || github.event.repository.name }}
         GITHUB_TOKEN: ${{ inputs.token }}
-        GITHUB_CONTEXT: "e2e / ${{inputs.account}}"
+        GITHUB_CONTEXT: "e2e / ${{inputs.region}}"
         GITHUB_DESCRIPTION: "run failed"
         GITHUB_TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
         GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref || github.ref_name }}
@@ -146,7 +135,7 @@ runs:
         REPO_SHA: ${{ github.event.client_payload.pull_request.head.sha || github.sha }}
         REPO_NAME: ${{ github.event.client_payload.github.payload.repository.name || github.event.repository.name }}
         GITHUB_TOKEN: ${{ inputs.token }}
-        GITHUB_CONTEXT: "e2e / ${{inputs.account}}"
+        GITHUB_CONTEXT: "e2e / ${{inputs.region}}"
         GITHUB_DESCRIPTION: "run cancelled"
         GITHUB_TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
         GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref || github.ref_name }}

--- a/.github/actions/e2e/action.yml
+++ b/.github/actions/e2e/action.yml
@@ -12,6 +12,9 @@ inputs:
   role-to-assume:
     description: The AWS IAM Role to assume in the target account
     required: true
+  github-context:
+    description: The GitHub Status Context to use when updating the status
+    required: true
 
 runs:
   using: composite
@@ -26,7 +29,7 @@ runs:
         REPO_SHA: ${{ github.event.client_payload.pull_request.head.sha || github.sha }}
         REPO_NAME: ${{ github.event.client_payload.github.payload.repository.name || github.event.repository.name }}
         GITHUB_TOKEN: ${{ inputs.token }}
-        GITHUB_CONTEXT: "e2e / ${{inputs.region}}"
+        GITHUB_CONTEXT: ${{ inputs.github-context }}
         GITHUB_DESCRIPTION: "started by @${{ github.event.client_payload.github.actor || github.actor }}"
         GITHUB_TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
         GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref || github.ref_name }}
@@ -103,7 +106,7 @@ runs:
         REPO_SHA: ${{ github.event.client_payload.pull_request.head.sha || github.sha }}
         REPO_NAME: ${{ github.event.client_payload.github.payload.repository.name || github.event.repository.name }}
         GITHUB_TOKEN: ${{ inputs.token }}
-        GITHUB_CONTEXT: "e2e / ${{inputs.region}}"
+        GITHUB_CONTEXT: ${{ inputs.github-context }}
         GITHUB_DESCRIPTION: "run passed"
         GITHUB_TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
         GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref || github.ref_name }}
@@ -119,7 +122,7 @@ runs:
         REPO_SHA: ${{ github.event.client_payload.pull_request.head.sha || github.sha }}
         REPO_NAME: ${{ github.event.client_payload.github.payload.repository.name || github.event.repository.name }}
         GITHUB_TOKEN: ${{ inputs.token }}
-        GITHUB_CONTEXT: "e2e / ${{inputs.region}}"
+        GITHUB_CONTEXT: ${{ inputs.github-context }}
         GITHUB_DESCRIPTION: "run failed"
         GITHUB_TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
         GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref || github.ref_name }}
@@ -135,7 +138,7 @@ runs:
         REPO_SHA: ${{ github.event.client_payload.pull_request.head.sha || github.sha }}
         REPO_NAME: ${{ github.event.client_payload.github.payload.repository.name || github.event.repository.name }}
         GITHUB_TOKEN: ${{ inputs.token }}
-        GITHUB_CONTEXT: "e2e / ${{inputs.region}}"
+        GITHUB_CONTEXT: ${{ inputs.github-context }}
         GITHUB_DESCRIPTION: "run cancelled"
         GITHUB_TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
         GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref || github.ref_name }}

--- a/.github/actions/e2e/action.yml
+++ b/.github/actions/e2e/action.yml
@@ -32,14 +32,6 @@ runs:
         GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref || github.ref_name }}
         GITHUB_OWNER: ${{ github.event.client_payload.github.payload.repository.owner.login || github.repository_owner }}
 
-    # Checkout the code from GitHub Pull Request
-    - name: "Checkout the code"
-      uses: actions/checkout@v3
-      with:
-        token: ${{ inputs.token }}
-        repository: ${{ github.event.client_payload.pull_request.head.repo.full_name || github.repository }}
-        ref: ${{ github.event.client_payload.pull_request.head.ref || github.ref_name }}
-
     - name: Init gopath cache
       uses: actions/cache@v3
       with:

--- a/.github/actions/e2e/action.yml
+++ b/.github/actions/e2e/action.yml
@@ -61,15 +61,18 @@ runs:
 
     - name: Docker save build harness
       if: steps.init-docker-cache.outputs.cache-hit != 'true'
+      shell: bash -e -o pipefail {0}
       run: |
         make docker-save-build-harness
 
     - name: Load build harness
+      shell: bash -e -o pipefail {0}
       run: |
         make docker-load-build-harness
 
     - name: Get Terraform version from .tool-versions
       id: get_tf_version
+      shell: bash -e -o pipefail {0}
       run: echo "tf_version=$(grep 'terraform ' .tool-versions)" >> $GITHUB_OUTPUT
 
     - name: Init Terraform Cache
@@ -99,9 +102,7 @@ runs:
         role-duration-seconds: 21600
 
     - name: "Run E2E tests"
-      env:
-        REPO_URL: https://github.com/${{ github.repository }}.git
-        GIT_BRANCH: ${{ github.event.client_payload.pull_request.head.ref || github.ref_name }}
+      shell: bash -e -o pipefail {0}
       run: |
         make test fix-cache-permissions
 

--- a/.github/actions/parse-test/action.yml
+++ b/.github/actions/parse-test/action.yml
@@ -1,0 +1,50 @@
+name: Parse Slash Command Dispatch (/test)
+
+description: Parse Slash Command Dispatch (/test)
+
+outputs:
+  run-ping:
+    description: Will be 'true' if the 'ping' job should run
+    value: ${{ steps.parse.outputs.ping }}
+  run-e2e:
+    description: Will be 'true' if the 'e2e' job should run
+    value: ${{ steps.parse.outputs.e2e }}
+
+runs:
+  using: composite
+  steps:
+    - name: Parse Args
+      id: parse
+      env:
+        DEBUG: ${{ toJSON(github.event.client_payload.slash_command) }}
+        ARGS_V1: ${{ github.event.client_payload.slash_command.arg1 }}
+        ARGS_V2: ${{ github.event.client_payload.slash_command.args.unnamed.all }}
+        EVENT_NAME: ${{ github.event_name }}
+      shell: bash -e -o pipefail {0}
+      run: |
+        ARGS="${ARGS_V1}${ARGS_V2}"
+        # set ARGS to "all" if EVENT_NAME is "push"
+        if [[ "${EVENT_NAME}" == "push" ]]; then
+            ARGS="all"
+        fi
+        printf "Event name is %s\n" "$EVENT_NAME"
+        printf "Args are %s\n" "$ARGS"
+        printf "\n\nslash_command is %s\n\n" "$DEBUG"
+        COMMANDS=(PING E2E) #all options here
+        if printf "%s" "${ARGS^^}" | grep -qE '\bALL\b'; then
+          # "all" explicitly does not include "ping"
+          for cmd in "${COMMANDS[@]}"; do
+            [[ $cmd == "PING" ]] && ! { printf "%s" "${ARGS^^}" | grep -qE '\bPING\b'; } && continue
+            printf -v "$cmd" "true"
+          done
+        else
+          for cmd in "${COMMANDS[@]}"; do
+            if printf "%s" "${ARGS^^}" | grep -qE "\b${cmd}\b"; then
+              printf -v "$cmd" "true"
+            fi
+          done
+        fi
+        for out in "${COMMANDS[@]}"; do
+          printf "%s=%s\n" "${out,,}" "${!out:-false}" >> $GITHUB_OUTPUT
+          printf "%s=%s\n" "${out,,}" "${!out:-false}"
+        done

--- a/.github/actions/ping/action.yml
+++ b/.github/actions/ping/action.yml
@@ -1,0 +1,20 @@
+name: Ping test
+
+description: Simple test that validates that an action can update a workflow status.
+
+runs:
+  using: composite
+  steps:
+    # Update GitHub status for dispatch events
+    - name: "Update GitHub Status for this ref"
+      if: github.event_name == 'repository_dispatch'
+      uses: "docker://cloudposse/github-status-updater"
+      with:
+        args: "-action update_state -state success -ref ${{ github.event.client_payload.pull_request.head.sha }} -repo ${{ github.event.client_payload.github.payload.repository.name }}"
+      env:
+        GITHUB_TOKEN: ${{ secrets.PAT }}
+        GITHUB_CONTEXT: "ping"
+        GITHUB_DESCRIPTION: "pong"
+        GITHUB_TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref }}
+        GITHUB_OWNER: ${{ github.event.client_payload.github.payload.repository.owner.login }}

--- a/.github/actions/ping/action.yml
+++ b/.github/actions/ping/action.yml
@@ -2,6 +2,11 @@ name: Ping test
 
 description: Simple test that validates that an action can update a workflow status.
 
+inputs:
+  token:
+    description: Personal Access Token (PAT) used to update the comment
+    required: true
+
 runs:
   using: composite
   steps:
@@ -12,7 +17,7 @@ runs:
       with:
         args: "-action update_state -state success -ref ${{ github.event.client_payload.pull_request.head.sha }} -repo ${{ github.event.client_payload.github.payload.repository.name }}"
       env:
-        GITHUB_TOKEN: ${{ secrets.PAT }}
+        GITHUB_TOKEN: ${{ inputs.token }}
         GITHUB_CONTEXT: "ping"
         GITHUB_DESCRIPTION: "pong"
         GITHUB_TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/actions/pre-commit/action.yml
+++ b/.github/actions/pre-commit/action.yml
@@ -18,14 +18,14 @@
           key: "pre-commit-${{inputs.check-type}}|${{hashFiles('.tool-versions')}}|${{hashFiles('.pre-commit-config.yaml')}}"
 
       - name: Init gopath cache
-        if: inputs.check-type == 'golang'
+        if: inputs.check-type == 'golang' || inputs.check-type == 'all'
         uses: actions/cache@v3
         with:
           path: "${{ github.workspace }}/.cache/go"
           key: "gopath|${{hashFiles('.tool-versions')}}|${{hashFiles('go.sum')}}"
 
       - name: Init gobuild cache
-        if: inputs.check-type == 'golang'
+        if: inputs.check-type == 'golang' || inputs.check-type == 'all'
         uses: actions/cache@v3
         with:
           path: "${{ github.workspace }}/.cache/go-build"
@@ -40,13 +40,13 @@
 
       - name: Docker save build harness
         if: steps.init-docker-cache.outputs.cache-hit != 'true'
-        shell: bash
+        shell: bash -e -o pipefail {0}
         run: make docker-save-build-harness
 
       - name: Load build harness
-        shell: bash
+        shell: bash -e -o pipefail {0}
         run: make docker-load-build-harness
 
       - name: Run `pre-commit run -a`
-        shell: bash
+        shell: bash -e -o pipefail {0}
         run: "make pre-commit-${{inputs.check-type}} fix-cache-permissions"

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Parse Args
         id: parse
-        uses: ./.github/actions/parse
+        uses: ./.github/actions/parse-test
 
   # Update the comment that triggered the /test command to show the run url
   comment:

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -28,14 +28,19 @@ jobs:
       run-ping: ${{ steps.parse.outputs.run-ping }}
       run-e2e: ${{ steps.parse.outputs.run-e2e }}
     steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
       - name: Parse Args
         id: parse
         uses: ./.github/actions/parse
 
   # Update the comment that triggered the /test command to show the run url
   comment:
+    if: github.event_name == 'repository_dispatch'
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
       - name: Update Comment
         uses: ./.github/actions/comment
 
@@ -45,6 +50,8 @@ jobs:
     needs: parse
     if: needs.parse.outputs.run-ping == 'true'
     steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
       - name: Ping Test
         uses: ./.github/actions/ping
 
@@ -54,6 +61,8 @@ jobs:
     needs: parse
     if: needs.parse.outputs.run-e2e == 'true'
     steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
       - name: Run E2E Tests
         uses: ./.github/actions/e2e
         with:
@@ -65,6 +74,8 @@ jobs:
     needs: parse
     if: needs.parse.outputs.run-e2e == 'true'
     steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
       - name: Run E2E Tests
         uses: ./.github/actions/e2e
         with:

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
       - main
+      - feature/include-govcloud-in-tests-2
 
 permissions:
   id-token: write
@@ -19,50 +20,24 @@ defaults:
     shell: bash -e -o pipefail {0}
 
 jobs:
-  # Parse the command so we can decide which tests to run. Examples: "/test all", "/test validate", "/test e2e"
+  # Parse the command, so we can decide which tests to run. Examples: "/test all", "/test validate", "/test e2e"
   # We can do as many of these as we want to get as granular as we want.
   parse:
     runs-on: ubuntu-latest
     outputs:
-      run-ping: ${{ steps.parse.outputs.ping }}
-      run-build: ${{ steps.parse.outputs.build }}
-      run-e2e: ${{ steps.parse.outputs.e2e }}
+      run-ping: ${{ steps.parse.outputs.run-ping }}
+      run-e2e: ${{ steps.parse.outputs.run-e2e }}
     steps:
       - name: Parse Args
         id: parse
-        env:
-          DEBUG: ${{ toJSON(github.event.client_payload.slash_command) }}
-          ARGS_V1: ${{ github.event.client_payload.slash_command.arg1 }}
-          ARGS_V2: ${{ github.event.client_payload.slash_command.args.unnamed.all }}
-          EVENT_NAME: ${{ github.event_name }}
-        shell: bash
-        run: |
-          ARGS="${ARGS_V1}${ARGS_V2}"
-          # set ARGS to "all" if EVENT_NAME is "push"
-          if [[ "${EVENT_NAME}" == "push" ]]; then
-              ARGS="all"
-          fi
-          printf "Event name is %s\n" "$EVENT_NAME"
-          printf "Args are %s\n" "$ARGS"
-          printf "\n\nslash_command is %s\n\n" "$DEBUG"
-          COMMANDS=(PING E2E) #all options here
-          if printf "%s" "${ARGS^^}" | grep -qE '\bALL\b'; then
-            # "all" explicitly does not include "ping"
-            for cmd in "${COMMANDS[@]}"; do
-              [[ $cmd == "PING" ]] && ! { printf "%s" "${ARGS^^}" | grep -qE '\bPING\b'; } && continue
-              printf -v "$cmd" "true"
-            done
-          else
-            for cmd in "${COMMANDS[@]}"; do
-              if printf "%s" "${ARGS^^}" | grep -qE "\b${cmd}\b"; then
-                printf -v "$cmd" "true"
-              fi
-            done
-          fi
-          for out in "${COMMANDS[@]}"; do
-            printf "%s=%s\n" "${out,,}" "${!out:-false}" >> $GITHUB_OUTPUT
-            printf "%s=%s\n" "${out,,}" "${!out:-false}"
-          done
+        uses: ./.github/actions/parse
+
+  # Update the comment that triggered the /test command to show the run url
+  comment:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update Comment
+        uses: ./.github/actions/comment
 
   # Do a simple ping/pong status update to validate things are working
   ping:
@@ -70,189 +45,27 @@ jobs:
     needs: parse
     if: needs.parse.outputs.run-ping == 'true'
     steps:
-      - name: Create URL to the run output
-        if: github.event_name == 'repository_dispatch'
-        id: vars
-        run: echo "run-url=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" >> $GITHUB_OUTPUT
+      - name: Ping Test
+        uses: ./.github/actions/ping
 
-      # Will update the comment that triggered the /test comment and add the run-url
-      - name: Update comment
-        if: github.event_name == 'repository_dispatch'
-        uses: peter-evans/create-or-update-comment@v3
-        with:
-          token: ${{ secrets.PAT }}
-          repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
-          comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
-          body: |
-            :robot: [View pipeline run][1]
-
-            [1]: ${{ steps.vars.outputs.run-url }}
-
-      # Update GitHub status for dispatch events
-      - name: "Update GitHub Status for this ref"
-        uses: "docker://cloudposse/github-status-updater"
-        with:
-          args: "-action update_state -state success -ref ${{ github.event.client_payload.pull_request.head.sha }} -repo ${{ github.event.client_payload.github.payload.repository.name }}"
-        env:
-          GITHUB_TOKEN: ${{ secrets.PAT }}
-          GITHUB_CONTEXT: "test / ping (${{ github.event_name }})"
-          GITHUB_DESCRIPTION: "pong"
-          GITHUB_TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref }}
-          GITHUB_OWNER: ${{ github.event.client_payload.github.payload.repository.owner.login }}
-
-  # Run the E2E tests
-  e2e:
+  # Run the E2E tests on the commercial account
+  e2e-commercial:
     runs-on: ubuntu-latest
     needs: parse
     if: needs.parse.outputs.run-e2e == 'true'
     steps:
-      # Update GitHub status for pending pipeline run
-      - name: "Update GitHub Status for pending"
-        if: github.event_name == 'repository_dispatch'
-        uses: docker://cloudposse/github-status-updater
+      - name: Run E2E Tests
+        uses: ./.github/actions/e2e
         with:
-          args: "-action update_state -state pending -ref ${{ env.REPO_SHA }} -repo ${{ env.REPO_NAME }}"
-        env:
-          REPO_SHA: ${{ github.event.client_payload.pull_request.head.sha || github.sha }}
-          REPO_NAME: ${{ github.event.client_payload.github.payload.repository.name || github.event.repository.name }}
-          GITHUB_TOKEN: ${{ secrets.PAT }}
-          GITHUB_CONTEXT: "test / e2e (${{ github.event_name }})"
-          GITHUB_DESCRIPTION: "started by @${{ github.event.client_payload.github.actor || github.actor }}"
-          GITHUB_TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref || github.ref_name }}
-          GITHUB_OWNER: ${{ github.event.client_payload.github.payload.repository.owner.login || github.repository_owner }}
+          account: commercial
 
-      - name: Create URL to the run output
-        if: github.event_name == 'repository_dispatch'
-        id: vars
-        run: echo "run-url=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" >> $GITHUB_OUTPUT
-
-      # Will update the comment that triggered the /test comment and add the run-url
-      - name: Update comment
-        if: github.event_name == 'repository_dispatch'
-        uses: peter-evans/create-or-update-comment@v3
+  # Run the E2E tests on the govcloud account
+  e2e-govcloud:
+    runs-on: ubuntu-latest
+    needs: parse
+    if: needs.parse.outputs.run-e2e == 'true'
+    steps:
+      - name: Run E2E Tests
+        uses: ./.github/actions/e2e
         with:
-          token: ${{ secrets.PAT }}
-          repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
-          comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
-          body: |
-            :robot: [View pipeline run][1]
-
-            [1]: ${{ steps.vars.outputs.run-url }}
-
-      # Checkout the code from GitHub Pull Request
-      - name: "Checkout the code"
-        uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.PAT }}
-          repository: ${{ github.event.client_payload.pull_request.head.repo.full_name || github.repository }}
-          ref: ${{ github.event.client_payload.pull_request.head.ref || github.ref_name }}
-
-      - name: Init gopath cache
-        uses: actions/cache@v3
-        with:
-          path: "${{ github.workspace }}/.cache/go"
-          key: "gopath|${{ hashFiles('.tool-versions') }}|${{ hashFiles('go.sum') }}"
-
-      - name: Init gobuild cache
-        uses: actions/cache@v3
-        with:
-          path: "${{ github.workspace }}/.cache/go-build"
-          key: "gobuild|${{ hashFiles('.tool-versions') }}|${{ hashFiles('go.sum') }}"
-
-      - name: Init zarf cache
-        uses: actions/cache@v3
-        with:
-          path: "${{ github.workspace }}/.cache/.zarf-cache"
-          key: "zarf|${{ hashFiles('.tool-versions') }}"
-
-      - name: Init docker cache
-        id: init-docker-cache
-        uses: actions/cache@v3
-        with:
-          path: "${{ github.workspace }}/.cache/docker"
-          key: "docker|${{ hashFiles('.env') }}"
-
-      - name: Docker save build harness
-        if: steps.init-docker-cache.outputs.cache-hit != 'true'
-        run: |
-          make docker-save-build-harness
-
-      - name: Load build harness
-        run: |
-          make docker-load-build-harness
-
-      - name: Get Terraform version from .tool-versions
-        id: get_tf_version
-        run: echo "tf_version=$(grep 'terraform ' .tool-versions)" >> $GITHUB_OUTPUT
-
-      - name: Init Terraform Cache
-        uses: actions/cache@v3
-        with:
-          path: "${{ github.workspace }}/.cache/.terraform.d/plugin-cache"
-          key: "${{ runner.os }}-terraform-plugins|${{ steps.get_tf_version.outputs.tf_version }}|${{ hashFiles('examples/complete/providers.tf') }}"
-
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          role-session-name: ${{ github.event.client_payload.pull_request.head.sha || github.sha }}
-          aws-region: us-east-1
-          # 21600 seconds == 6 hours
-          role-duration-seconds: 21600
-
-      - name: "Run E2E tests"
-        env:
-          REPO_URL: https://github.com/${{ github.repository }}.git
-          GIT_BRANCH: ${{ github.event.client_payload.pull_request.head.ref || github.ref_name }}
-        run: |
-          make test fix-cache-permissions
-
-      # Update GitHub status for failing pipeline run
-      - name: "Update GitHub Status for failure"
-        if: ${{ failure() && github.event_name == 'repository_dispatch' }}
-        uses: docker://cloudposse/github-status-updater
-        with:
-          args: "-action update_state -state failure -ref ${{ env.REPO_SHA }} -repo ${{ env.REPO_NAME }}"
-        env:
-          REPO_SHA: ${{ github.event.client_payload.pull_request.head.sha || github.sha }}
-          REPO_NAME: ${{ github.event.client_payload.github.payload.repository.name || github.event.repository.name }}
-          GITHUB_TOKEN: ${{ secrets.PAT }}
-          GITHUB_CONTEXT: "test / e2e (${{ github.event_name }})"
-          GITHUB_DESCRIPTION: "run failed"
-          GITHUB_TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref || github.ref_name }}
-          GITHUB_OWNER: ${{ github.event.client_payload.github.payload.repository.owner.login || github.repository_owner }}
-
-      # Update GitHub status for successful pipeline run
-      - name: "Update GitHub Status for success"
-        if: github.event_name == 'repository_dispatch'
-        uses: docker://cloudposse/github-status-updater
-        with:
-          args: "-action update_state -state success -ref ${{ env.REPO_SHA }} -repo ${{ env.REPO_NAME }}"
-        env:
-          REPO_SHA: ${{ github.event.client_payload.pull_request.head.sha || github.sha }}
-          REPO_NAME: ${{ github.event.client_payload.github.payload.repository.name || github.event.repository.name }}
-          GITHUB_TOKEN: ${{ secrets.PAT }}
-          GITHUB_CONTEXT: "test / e2e (${{ github.event_name }})"
-          GITHUB_DESCRIPTION: "run passed"
-          GITHUB_TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref || github.ref_name }}
-          GITHUB_OWNER: ${{ github.event.client_payload.github.payload.repository.owner.login || github.repository_owner }}
-
-      # Update GitHub status for cancelled pipeline run
-      - name: "Update GitHub Status for cancelled"
-        if: ${{ cancelled() && github.event_name == 'repository_dispatch' }}
-        uses: docker://cloudposse/github-status-updater
-        with:
-          args: "-action update_state -state error -ref ${{ env.REPO_SHA }} -repo ${{ env.REPO_NAME }}"
-        env:
-          REPO_SHA: ${{ github.event.client_payload.pull_request.head.sha || github.sha }}
-          REPO_NAME: ${{ github.event.client_payload.github.payload.repository.name || github.event.repository.name }}
-          GITHUB_TOKEN: ${{ secrets.PAT }}
-          GITHUB_CONTEXT: "test / e2e (${{ github.event_name }})"
-          GITHUB_DESCRIPTION: "run cancelled"
-          GITHUB_TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref || github.ref_name }}
-          GITHUB_OWNER: ${{ github.event.client_payload.github.payload.repository.owner.login || github.repository_owner }}
+          account: govcloud

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -8,7 +8,6 @@ on:
   push:
     branches:
       - main
-      - feature/include-govcloud-in-tests-2
 
 permissions:
   id-token: write
@@ -85,6 +84,7 @@ jobs:
           token: ${{ secrets.PAT }}
           role-to-assume: ${{ secrets.AWS_COMMERCIAL_ROLE_TO_ASSUME }}
           region: us-east-1
+          github-context: "test / e2e-commercial (${{github.event_name}})"
 
   # Run the E2E tests on the govcloud account
   e2e-govcloud:
@@ -104,3 +104,4 @@ jobs:
           token: ${{ secrets.PAT }}
           role-to-assume: ${{ secrets.AWS_GOVCLOUD_ROLE_TO_ASSUME }}
           region: us-gov-west-1
+          github-context: "test / e2e-govcloud (${{github.event_name}})"

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -83,8 +83,8 @@ jobs:
         uses: ./.github/actions/e2e
         with:
           token: ${{ secrets.PAT }}
-          account: commercial
           role-to-assume: ${{ secrets.AWS_COMMERCIAL_ROLE_TO_ASSUME }}
+          region: us-east-1
 
   # Run the E2E tests on the govcloud account
   e2e-govcloud:
@@ -102,5 +102,5 @@ jobs:
         uses: ./.github/actions/e2e
         with:
           token: ${{ secrets.PAT }}
-          account: govcloud
           role-to-assume: ${{ secrets.AWS_GOVCLOUD_ROLE_TO_ASSUME }}
+          region: us-gov-west-1

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -28,8 +28,12 @@ jobs:
       run-ping: ${{ steps.parse.outputs.run-ping }}
       run-e2e: ${{ steps.parse.outputs.run-e2e }}
     steps:
-      - name: Checkout repo
+      - name: Checkout Repo
         uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.PAT }}
+          repository: ${{ github.event.client_payload.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event.client_payload.pull_request.head.ref || github.ref_name }}
       - name: Parse Args
         id: parse
         uses: ./.github/actions/parse-test
@@ -39,8 +43,12 @@ jobs:
     if: github.event_name == 'repository_dispatch'
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repo
+      - name: Checkout Repo
         uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.PAT }}
+          repository: ${{ github.event.client_payload.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event.client_payload.pull_request.head.ref || github.ref_name }}
       - name: Update Comment
         uses: ./.github/actions/comment
 
@@ -50,8 +58,12 @@ jobs:
     needs: parse
     if: needs.parse.outputs.run-ping == 'true'
     steps:
-      - name: Checkout repo
+      - name: Checkout Repo
         uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.PAT }}
+          repository: ${{ github.event.client_payload.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event.client_payload.pull_request.head.ref || github.ref_name }}
       - name: Ping Test
         uses: ./.github/actions/ping
 
@@ -61,12 +73,18 @@ jobs:
     needs: parse
     if: needs.parse.outputs.run-e2e == 'true'
     steps:
-      - name: Checkout repo
+      - name: Checkout Repo
         uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.PAT }}
+          repository: ${{ github.event.client_payload.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event.client_payload.pull_request.head.ref || github.ref_name }}
       - name: Run E2E Tests
         uses: ./.github/actions/e2e
         with:
+          token: ${{ secrets.PAT }}
           account: commercial
+          role-to-assume: ${{ secrets.AWS_COMMERCIAL_ROLE_TO_ASSUME }}
 
   # Run the E2E tests on the govcloud account
   e2e-govcloud:
@@ -74,9 +92,15 @@ jobs:
     needs: parse
     if: needs.parse.outputs.run-e2e == 'true'
     steps:
-      - name: Checkout repo
+      - name: Checkout Repo
         uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.PAT }}
+          repository: ${{ github.event.client_payload.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event.client_payload.pull_request.head.ref || github.ref_name }}
       - name: Run E2E Tests
         uses: ./.github/actions/e2e
         with:
+          token: ${{ secrets.PAT }}
           account: govcloud
+          role-to-assume: ${{ secrets.AWS_GOVCLOUD_ROLE_TO_ASSUME }}

--- a/Makefile
+++ b/Makefile
@@ -34,39 +34,35 @@ _create-folders:
 
 .PHONY: _test-all
 _test-all: _create-folders
-	echo "mock"
-
-#.PHONY: _test-all
-#_test-all: _create-folders
-#	echo "Running automated tests. This will take several minutes. At times it does not log anything to the console. If you interrupt the test run you will need to log into AWS console and manually delete any orphaned infrastructure."
-#	docker run $(TTY_ARG) --rm \
-#		--cap-add=NET_ADMIN \
-#		--cap-add=NET_RAW \
-#		-v "${PWD}:/app" \
-#		-v "${PWD}/.cache/tmp:/tmp" \
-#		-v "${PWD}/.cache/go:/root/go" \
-#		-v "${PWD}/.cache/go-build:/root/.cache/go-build" \
-#		-v "${PWD}/.cache/.terraform.d/plugin-cache:/root/.terraform.d/plugin-cache" \
-#		-v "${PWD}/.cache/.zarf-cache:/root/.zarf-cache" \
-#		--workdir "/app" \
-#		-e TF_LOG_PATH \
-#		-e TF_LOG \
-#		-e GOPATH=/root/go \
-#		-e GOCACHE=/root/.cache/go-build \
-#		-e TF_PLUGIN_CACHE_MAY_BREAK_DEPENDENCY_LOCK_FILE=true \
-#		-e TF_PLUGIN_CACHE_DIR=/root/.terraform.d/plugin-cache \
-#		-e AWS_REGION \
-#		-e AWS_DEFAULT_REGION \
-#		-e AWS_ACCESS_KEY_ID \
-#		-e AWS_SECRET_ACCESS_KEY \
-#		-e AWS_SESSION_TOKEN \
-#		-e AWS_SECURITY_TOKEN \
-#		-e AWS_SESSION_EXPIRATION \
-#		-e SKIP_SETUP \
-#		-e SKIP_TEST \
-#		-e SKIP_TEARDOWN \
-#		${BUILD_HARNESS_REPO}:${BUILD_HARNESS_VERSION} \
-#		bash -c 'git config --global --add safe.directory /app && asdf install && cd examples/complete && terraform init -upgrade=true && cd ../../test/e2e && go test -count 1 -v $(EXTRA_TEST_ARGS) .'
+	echo "Running automated tests. This will take several minutes. At times it does not log anything to the console. If you interrupt the test run you will need to log into AWS console and manually delete any orphaned infrastructure."
+	docker run $(TTY_ARG) --rm \
+		--cap-add=NET_ADMIN \
+		--cap-add=NET_RAW \
+		-v "${PWD}:/app" \
+		-v "${PWD}/.cache/tmp:/tmp" \
+		-v "${PWD}/.cache/go:/root/go" \
+		-v "${PWD}/.cache/go-build:/root/.cache/go-build" \
+		-v "${PWD}/.cache/.terraform.d/plugin-cache:/root/.terraform.d/plugin-cache" \
+		-v "${PWD}/.cache/.zarf-cache:/root/.zarf-cache" \
+		--workdir "/app" \
+		-e TF_LOG_PATH \
+		-e TF_LOG \
+		-e GOPATH=/root/go \
+		-e GOCACHE=/root/.cache/go-build \
+		-e TF_PLUGIN_CACHE_MAY_BREAK_DEPENDENCY_LOCK_FILE=true \
+		-e TF_PLUGIN_CACHE_DIR=/root/.terraform.d/plugin-cache \
+		-e AWS_REGION \
+		-e AWS_DEFAULT_REGION \
+		-e AWS_ACCESS_KEY_ID \
+		-e AWS_SECRET_ACCESS_KEY \
+		-e AWS_SESSION_TOKEN \
+		-e AWS_SECURITY_TOKEN \
+		-e AWS_SESSION_EXPIRATION \
+		-e SKIP_SETUP \
+		-e SKIP_TEST \
+		-e SKIP_TEARDOWN \
+		${BUILD_HARNESS_REPO}:${BUILD_HARNESS_VERSION} \
+		bash -c 'git config --global --add safe.directory /app && asdf install && cd examples/complete && terraform init -upgrade=true && cd ../../test/e2e && go test -count 1 -v $(EXTRA_TEST_ARGS) .'
 
 .PHONY: bastion-connect
 bastion-connect: _create-folders ## To be used after deploying "secure mode" of examples/complete. It (a) creates a tunnel through the bastion host using sshuttle, and (b) sets up the KUBECONFIG so that the EKS cluster is able to be interacted with. Requires the standard AWS cred environment variables to be set. We recommend using 'aws-vault' to set them.

--- a/Makefile
+++ b/Makefile
@@ -34,35 +34,39 @@ _create-folders:
 
 .PHONY: _test-all
 _test-all: _create-folders
-	echo "Running automated tests. This will take several minutes. At times it does not log anything to the console. If you interrupt the test run you will need to log into AWS console and manually delete any orphaned infrastructure."
-	docker run $(TTY_ARG) --rm \
-		--cap-add=NET_ADMIN \
-		--cap-add=NET_RAW \
-		-v "${PWD}:/app" \
-		-v "${PWD}/.cache/tmp:/tmp" \
-		-v "${PWD}/.cache/go:/root/go" \
-		-v "${PWD}/.cache/go-build:/root/.cache/go-build" \
-		-v "${PWD}/.cache/.terraform.d/plugin-cache:/root/.terraform.d/plugin-cache" \
-		-v "${PWD}/.cache/.zarf-cache:/root/.zarf-cache" \
-		--workdir "/app" \
-		-e TF_LOG_PATH \
-		-e TF_LOG \
-		-e GOPATH=/root/go \
-		-e GOCACHE=/root/.cache/go-build \
-		-e TF_PLUGIN_CACHE_MAY_BREAK_DEPENDENCY_LOCK_FILE=true \
-		-e TF_PLUGIN_CACHE_DIR=/root/.terraform.d/plugin-cache \
-		-e AWS_REGION \
-		-e AWS_DEFAULT_REGION \
-		-e AWS_ACCESS_KEY_ID \
-		-e AWS_SECRET_ACCESS_KEY \
-		-e AWS_SESSION_TOKEN \
-		-e AWS_SECURITY_TOKEN \
-		-e AWS_SESSION_EXPIRATION \
-		-e SKIP_SETUP \
-		-e SKIP_TEST \
-		-e SKIP_TEARDOWN \
-		${BUILD_HARNESS_REPO}:${BUILD_HARNESS_VERSION} \
-		bash -c 'git config --global --add safe.directory /app && asdf install && cd examples/complete && terraform init -upgrade=true && cd ../../test/e2e && go test -count 1 -v $(EXTRA_TEST_ARGS) .'
+	echo "mock"
+
+#.PHONY: _test-all
+#_test-all: _create-folders
+#	echo "Running automated tests. This will take several minutes. At times it does not log anything to the console. If you interrupt the test run you will need to log into AWS console and manually delete any orphaned infrastructure."
+#	docker run $(TTY_ARG) --rm \
+#		--cap-add=NET_ADMIN \
+#		--cap-add=NET_RAW \
+#		-v "${PWD}:/app" \
+#		-v "${PWD}/.cache/tmp:/tmp" \
+#		-v "${PWD}/.cache/go:/root/go" \
+#		-v "${PWD}/.cache/go-build:/root/.cache/go-build" \
+#		-v "${PWD}/.cache/.terraform.d/plugin-cache:/root/.terraform.d/plugin-cache" \
+#		-v "${PWD}/.cache/.zarf-cache:/root/.zarf-cache" \
+#		--workdir "/app" \
+#		-e TF_LOG_PATH \
+#		-e TF_LOG \
+#		-e GOPATH=/root/go \
+#		-e GOCACHE=/root/.cache/go-build \
+#		-e TF_PLUGIN_CACHE_MAY_BREAK_DEPENDENCY_LOCK_FILE=true \
+#		-e TF_PLUGIN_CACHE_DIR=/root/.terraform.d/plugin-cache \
+#		-e AWS_REGION \
+#		-e AWS_DEFAULT_REGION \
+#		-e AWS_ACCESS_KEY_ID \
+#		-e AWS_SECRET_ACCESS_KEY \
+#		-e AWS_SESSION_TOKEN \
+#		-e AWS_SECURITY_TOKEN \
+#		-e AWS_SESSION_EXPIRATION \
+#		-e SKIP_SETUP \
+#		-e SKIP_TEST \
+#		-e SKIP_TEARDOWN \
+#		${BUILD_HARNESS_REPO}:${BUILD_HARNESS_VERSION} \
+#		bash -c 'git config --global --add safe.directory /app && asdf install && cd examples/complete && terraform init -upgrade=true && cd ../../test/e2e && go test -count 1 -v $(EXTRA_TEST_ARGS) .'
 
 .PHONY: bastion-connect
 bastion-connect: _create-folders ## To be used after deploying "secure mode" of examples/complete. It (a) creates a tunnel through the bastion host using sshuttle, and (b) sets up the KUBECONFIG so that the EKS cluster is able to be interacted with. Requires the standard AWS cred environment variables to be set. We recommend using 'aws-vault' to set them.


### PR DESCRIPTION
Closes #239

Changes:
- Significantly simplify the main `test-command.yml` workflow by abstracting the major sections of it into independent GitHub Actions
- Fix a bug in the pre-commit action that would incorrectly skip golang caching if `check-type` was set to `all`
- Update the E2E tests from one job that tests in the commercial account to 2 separate jobs that run in parallel; one for the commercial account and the other for the govcloud account.

Notes:
- (Repeated here for visibility) I believe this is good to go, but can't be 100% sure since a bunch of it only works out of the `main` branch. Recommended approach to reviewing this is to do a review of the code, get it merged, then open a dummy PR to test.