### PR TITLE
ADR on our branch protection settings

### DIFF
--- a/doc/adr/0007-branch-protection-settings.md
+++ b/doc/adr/0007-branch-protection-settings.md
@@ -25,7 +25,7 @@ We need to decide as a team what the branch protection setting will be on our re
     - Integration/E2E tests
   - Require conversation resolution before merging
   - Require signed commits
-  - Do not require linear history
+  - Require linear history
   - Do not require merge queue
   - Do not require deployments to succeed before merging
   - Do not lock the branch

--- a/doc/adr/0007-branch-protection-settings.md
+++ b/doc/adr/0007-branch-protection-settings.md
@@ -1,0 +1,35 @@
+# 7. Branch Protection Settings
+
+Date: 2023-07-27
+
+## Status
+
+Accepted
+
+## Context
+
+We need to decide as a team what the branch protection setting will be on our repo(s).
+
+## Decision
+
+- We will have a Branch protection rule with the branch name pattern of `main` that contains the following settings:
+  - Require pull request reviews before merging
+  - Require at least 1 approving review
+  - Dismiss stale pull request approvals when new commits are pushed
+  - Require review from Code Owners
+  - Restrict who can dismiss pull request reviews to the `defenseunicorns/delivery-aws-iac-admin` team
+  - Do not allow specified actors to bypass required pull requests
+  - Do not require approval of the most recent reviewable push
+  - Require status checks to pass before merging
+    - pre-commit status checks
+    - Integration/E2E tests
+  - Require conversation resolution before merging
+  - Do not require signed commits
+  - Do not require linear history
+  - Do not require merge queue
+  - Do not require deployments to succeed before merging
+  - Do not lock the branch
+  - Do not allow bypassing the above settings
+  - Restrict who can push to matching branches to organization administrators, repository administrators, and users with the Maintain role only
+  - Do not allow force pushes
+  - Do not allow deletions

--- a/doc/adr/0007-branch-protection-settings.md
+++ b/doc/adr/0007-branch-protection-settings.md
@@ -17,7 +17,7 @@ We need to decide as a team what the branch protection setting will be on our re
   - Require at least 1 approving review
   - Dismiss stale pull request approvals when new commits are pushed
   - Require review from Code Owners
-  - Restrict who can dismiss pull request reviews to the `defenseunicorns/delivery-aws-iac-admin` team
+  - Restrict who can dismiss pull request reviews to organization and repository administrators
   - Do not allow specified actors to bypass required pull requests
   - Do not require approval of the most recent reviewable push
   - Require status checks to pass before merging

--- a/doc/adr/0007-branch-protection-settings.md
+++ b/doc/adr/0007-branch-protection-settings.md
@@ -24,7 +24,7 @@ We need to decide as a team what the branch protection setting will be on our re
     - pre-commit status checks
     - Integration/E2E tests
   - Require conversation resolution before merging
-  - Do not require signed commits
+  - Require signed commits
   - Do not require linear history
   - Do not require merge queue
   - Do not require deployments to succeed before merging


### PR DESCRIPTION
Differences between what the settings are right now and what this documents (to discuss when we meet up next)

- Restrict who can dismiss pull request reviews: We don't need to specify the delivery-aws-iac-admin team since they are already given that ability due to being repository administrators.
- Required status checks to pass before merging currently only enforces the pre-commit status checks. From our conversations we are deciding we want to require the automated tests to pass as well.
- Renovate is currently allowed to push to main, we can take that away, unless we feel it is valuable to set up Renovate's auto-merge functionality.