### PR TITLE
chore(deps): help Renovate get around Checkov's IP block

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,5 +1,6 @@
 adr-tools 3.0.0
 awscli 2.13.1
+# renovate: datasource=git-tags depName=https://github.com/bridgecrewio/checkov.git
 checkov 2.3.234
 golang 1.20.6
 golangci-lint 1.53.3


### PR DESCRIPTION
Using a `git-tags` datasource uses the git protocol over HTTPS, as compared to `github-tags` which uses GitHub API, which for the Checkov repo has an IP allow-list resulting in Renovate being unable to check versions for Checkov