### PR TITLE
ci(test): Add ability to run Secure E2E and Insecure E2E tests separately, and only run Insecure test in commercial and Secure test in govcloud

### DIFF
--- a/.github/actions/e2e/action.yml
+++ b/.github/actions/e2e/action.yml
@@ -15,6 +15,9 @@ inputs:
   github-context:
     description: The GitHub Status Context to use when updating the status
     required: true
+  test-to-run:
+    description: Which test to run, either "secure" or "insecure"
+    required: true
 
 runs:
   using: composite
@@ -33,6 +36,14 @@ runs:
         GITHUB_TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
         GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref || github.ref_name }}
         GITHUB_OWNER: ${{ github.event.client_payload.github.payload.repository.owner.login || github.repository_owner }}
+
+    - name: Validate test-to-run input
+      shell: bash -e -o pipefail {0}
+      run: |
+          if [[ "${{ inputs.test-to-run }}" != "secure" && "${{ inputs.test-to-run }}" != "insecure" ]]; then
+          echo "Invalid test-to-run input: '${{ inputs.test-to-run }}'. Valid inputs are 'secure' or 'insecure'."
+          exit 1
+          fi
 
     - name: Init gopath cache
       uses: actions/cache@v3
@@ -90,23 +101,13 @@ runs:
         # 21600 seconds == 6 hours
         role-duration-seconds: 21600
 
-    - name: "Run Secure E2E tests"
-      if: inputs.github-context == 'test / e2e-govcloud'
+    - name: "Run E2E tests"
       shell: bash -e -o pipefail {0}
       env:
         TF_VAR_region: ${{ inputs.region }}
       run: |
-        echo "Running Secure E2E tests" && \
-        make test-complete-secure fix-cache-permissions
-
-    - name: "Run Insecure E2E tests"
-      if: inputs.github-context == 'test / e2e-commercial'
-      shell: bash -e -o pipefail {0}
-      env:
-        TF_VAR_region: ${{ inputs.region }}
-      run: |
-        echo "Running Insecure E2E tests" && \
-        make test-complete-insecure fix-cache-permissions
+        echo "Running E2E tests" && \
+        make test-complete-${{ inputs.test-to-run }} fix-cache-permissions
 
     # Update GitHub status for successful pipeline run
     - name: "Update GitHub Status for success"

--- a/.github/actions/e2e/action.yml
+++ b/.github/actions/e2e/action.yml
@@ -84,7 +84,7 @@ runs:
         path: "${{ github.workspace }}/.cache/.terraform.d/plugin-cache"
         key: "${{ runner.os }}-terraform-plugins|${{ steps.get_tf_version.outputs.tf_version }}|${{ hashFiles('examples/complete/providers.tf') }}"
 
-    - name: Configure AWS Credentials for Commercial
+    - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v2
       with:
         role-to-assume: ${{ inputs.role-to-assume }}
@@ -93,13 +93,25 @@ runs:
         # 21600 seconds == 6 hours
         role-duration-seconds: 21600
 
-    - name: "Run E2E tests"
+    - name: "Run Secure E2E tests"
+      if: inputs.github-context == 'test / e2e-govcloud'
       shell: bash -e -o pipefail {0}
       env:
         TF_VAR_region: ${{ inputs.region }}
         TF_VAR_region2: ${{ inputs.region2 }}
       run: |
-        make test fix-cache-permissions
+        echo "Running Secure E2E tests" && \
+        make test-complete-secure fix-cache-permissions
+
+    - name: "Run Insecure E2E tests"
+      if: inputs.github-context == 'test / e2e-commercial'
+      shell: bash -e -o pipefail {0}
+      env:
+        TF_VAR_region: ${{ inputs.region }}
+        TF_VAR_region2: ${{ inputs.region2 }}
+      run: |
+        echo "Running Insecure E2E tests" && \
+        make test-complete-insecure fix-cache-permissions
 
     # Update GitHub status for successful pipeline run
     - name: "Update GitHub Status for success"

--- a/.github/actions/e2e/action.yml
+++ b/.github/actions/e2e/action.yml
@@ -9,9 +9,6 @@ inputs:
   region:
     description: The AWS region to deploy to
     required: true
-  region2:
-    description: The alternate AWS region where cross-region backups will go
-    required: true
   role-to-assume:
     description: The AWS IAM Role to assume in the target account
     required: true
@@ -98,7 +95,6 @@ runs:
       shell: bash -e -o pipefail {0}
       env:
         TF_VAR_region: ${{ inputs.region }}
-        TF_VAR_region2: ${{ inputs.region2 }}
       run: |
         echo "Running Secure E2E tests" && \
         make test-complete-secure fix-cache-permissions
@@ -108,7 +104,6 @@ runs:
       shell: bash -e -o pipefail {0}
       env:
         TF_VAR_region: ${{ inputs.region }}
-        TF_VAR_region2: ${{ inputs.region2 }}
       run: |
         echo "Running Insecure E2E tests" && \
         make test-complete-insecure fix-cache-permissions

--- a/.github/actions/parse-test/action.yml
+++ b/.github/actions/parse-test/action.yml
@@ -6,12 +6,12 @@ outputs:
   run-ping:
     description: Will be 'true' if the 'ping' job should run
     value: ${{ steps.parse.outputs.ping }}
-  run-e2e-insecure:
-    description: Will be 'true' if the 'e2e-insecure' job should run
-    value: ${{ steps.parse.outputs.e2e_insecure }} # no hyphens in bash variables :)
-  run-e2e-secure:
-    description: Will be 'true' if the 'e2e-secure' job should run
-    value: ${{ steps.parse.outputs.e2e_secure }} # no hyphens in bash variables :)
+  run-e2e-commercial-insecure:
+    description: Will be 'true' if the 'e2e_commercial_insecure' job should run
+    value: ${{ steps.parse.outputs.e2e_commercial_insecure }}
+  run-e2e-govcloud-secure:
+    description: Will be 'true' if the 'e2e_govcloud_secure' job should run
+    value: ${{ steps.parse.outputs.e2e_govcloud_secure }}
 runs:
   using: composite
   steps:
@@ -27,7 +27,7 @@ runs:
         printf "Event name is %s\n" "$EVENT_NAME"
         printf "Args are %s\n" "$ARGS"
         printf "\n\nslash_command is %s\n\n" "$DEBUG"
-        COMMANDS=(PING E2E_SECURE E2E_INSECURE) #all options here
+        COMMANDS=(PING E2E_COMMERCIAL_INSECURE E2E_GOVCLOUD_SECURE) #all options here
         if printf "%s" "${ARGS^^}" | grep -qE '\bALL\b'; then
           # "all" explicitly does not include "ping"
           for cmd in "${COMMANDS[@]}"; do

--- a/.github/actions/parse-test/action.yml
+++ b/.github/actions/parse-test/action.yml
@@ -6,10 +6,12 @@ outputs:
   run-ping:
     description: Will be 'true' if the 'ping' job should run
     value: ${{ steps.parse.outputs.ping }}
-  run-e2e:
-    description: Will be 'true' if the 'e2e' job should run
-    value: ${{ steps.parse.outputs.e2e }}
-
+  run-e2e-insecure:
+    description: Will be 'true' if the 'e2e-insecure' job should run
+    value: ${{ steps.parse.outputs.e2e_insecure }} # no hyphens in bash variables :)
+  run-e2e-secure:
+    description: Will be 'true' if the 'e2e-secure' job should run
+    value: ${{ steps.parse.outputs.e2e_secure }} # no hyphens in bash variables :)
 runs:
   using: composite
   steps:
@@ -25,7 +27,7 @@ runs:
         printf "Event name is %s\n" "$EVENT_NAME"
         printf "Args are %s\n" "$ARGS"
         printf "\n\nslash_command is %s\n\n" "$DEBUG"
-        COMMANDS=(PING E2E) #all options here
+        COMMANDS=(PING E2E_SECURE E2E_INSECURE) #all options here
         if printf "%s" "${ARGS^^}" | grep -qE '\bALL\b'; then
           # "all" explicitly does not include "ping"
           for cmd in "${COMMANDS[@]}"; do

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -85,7 +85,6 @@ jobs:
           token: ${{ secrets.PAT }}
           role-to-assume: ${{ secrets.AWS_COMMERCIAL_ROLE_TO_ASSUME }}
           region: us-east-2
-          region2: us-east-1
           github-context: "test / e2e-commercial"
 
   # Run the E2E tests on the govcloud account
@@ -106,5 +105,4 @@ jobs:
           token: ${{ secrets.PAT }}
           role-to-assume: ${{ secrets.AWS_GOVCLOUD_ROLE_TO_ASSUME }}
           region: us-gov-east-1
-          region2: us-gov-west-1
           github-context: "test / e2e-govcloud"

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -22,8 +22,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       run-ping: ${{ steps.parse.outputs.run-ping }}
-      run-e2e-insecure: ${{ steps.parse.outputs.run-e2e-insecure }}
-      run-e2e-secure: ${{ steps.parse.outputs.run-e2e-secure }}
+      run-e2e-commercial-insecure: ${{ steps.parse.outputs.run-e2e-commercial-insecure }}
+      run-e2e-govcloud-secure: ${{ steps.parse.outputs.run-e2e-govcloud-secure }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
@@ -67,11 +67,11 @@ jobs:
         with:
           token: ${{ secrets.PAT }}
 
-  # Run the E2E tests on the commercial account
-  e2e-commercial:
+  # Run the E2E insecure tests on the commercial account
+  e2e-commercial-insecure:
     runs-on: ubuntu-latest
     needs: parse
-    if: needs.parse.outputs.run-e2e-insecure == 'true'
+    if: needs.parse.outputs.run-e2e-commercial-insecure == 'true'
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
@@ -85,13 +85,14 @@ jobs:
           token: ${{ secrets.PAT }}
           role-to-assume: ${{ secrets.AWS_COMMERCIAL_ROLE_TO_ASSUME }}
           region: us-east-2
-          github-context: "test / e2e-commercial"
+          github-context: "test / e2e-commercial-insecure"
+          test-to-run: "insecure"
 
-  # Run the E2E tests on the govcloud account
-  e2e-govcloud:
+  # Run the E2E secure tests on the govcloud account
+  e2e-govcloud-secure:
     runs-on: ubuntu-latest
     needs: parse
-    if: needs.parse.outputs.run-e2e-secure == 'true'
+    if: needs.parse.outputs.run-e2e-govcloud-secure == 'true'
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
@@ -105,4 +106,5 @@ jobs:
           token: ${{ secrets.PAT }}
           role-to-assume: ${{ secrets.AWS_GOVCLOUD_ROLE_TO_ASSUME }}
           region: us-gov-east-1
-          github-context: "test / e2e-govcloud"
+          github-context: "test / e2e-govcloud-secure"
+          test-to-run: "secure"

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -22,7 +22,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       run-ping: ${{ steps.parse.outputs.run-ping }}
-      run-e2e: ${{ steps.parse.outputs.run-e2e }}
+      run-e2e-insecure: ${{ steps.parse.outputs.run-e2e-insecure }}
+      run-e2e-secure: ${{ steps.parse.outputs.run-e2e-secure }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
@@ -70,7 +71,7 @@ jobs:
   e2e-commercial:
     runs-on: ubuntu-latest
     needs: parse
-    if: needs.parse.outputs.run-e2e == 'true'
+    if: needs.parse.outputs.run-e2e-insecure == 'true'
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
@@ -91,7 +92,7 @@ jobs:
   e2e-govcloud:
     runs-on: ubuntu-latest
     needs: parse
-    if: needs.parse.outputs.run-e2e == 'true'
+    if: needs.parse.outputs.run-e2e-secure == 'true'
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,9 @@ Specifically:
 
 1. Pick an issue to work on, assign it to yourself, and drop a comment in the issue to let everyone know you're working on it.
 2. Create a Draft Pull Request targeting the `main` branch as soon as you are able to, even if it is just 5 minutes after you started working on it. We lean towards working in the open as much as we can. If you're not sure what to put in the PR description, just put a link to the issue you're working on. If you're not sure what to put in the PR title, just put "WIP" (Work In Progress) and we'll help you out with the rest.
-3. :key: Automated tests will run on your PR when you create it and for each commit you push to it. The PR will also have manually triggered workflows that you can run (if you have write access to the repo) by commenting on the PR with `/test all`
+3. :key: The automated tests have to pass for the PR to be able to be merged. To run the tests add a comment to the PR that says `/test all`. If you want to run a specific test, you can use `/test <test name>`. The tests are:
+  - `e2e_commercial_insecure` - Runs the E2E insecure tests against the commercial environment
+  - `e2e_govcloud_secure` - Runs the E2E secure tests against the govcloud environment
 4. If your PR is still set as a Draft transition it to "Ready for Review"
 5. Get it reviewed by a [CODEOWNER](./CODEOWNERS)
 6. Merge the PR and delete the branch

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,6 @@ _test-all: _create-folders
 		-e SKIP_TEST \
 		-e SKIP_TEARDOWN \
 		-e TF_VAR_region \
-		-e TF_VAR_region2 \
 		${BUILD_HARNESS_REPO}:${BUILD_HARNESS_VERSION} \
 		bash -c 'git config --global --add safe.directory /app && asdf install && cd examples/complete && terraform init -upgrade=true && cd ../../test/e2e && go test -count 1 -v $(EXTRA_TEST_ARGS) .'
 


### PR DESCRIPTION
closes #318
closes #319 

These changes modify the functionality of the test command

`/test e2e_govcloud_secure` - just run secure test on govcloud
`/test e2e_commercial_insecure` - just run insecure test on commercial
`/test all` - run `e2e_govcloud_secure` and `e2e_commercial_insecure` tests

see: https://github.com/zack-is-cool/delivery-aws-iac/pull/5 for testing results