### PR TITLE
chore(ci): Add support for using the merge queue, refactor workflow file names, and add more docs to the workflow files

### DIFF
--- a/.github/workflows/merge-group.yml
+++ b/.github/workflows/merge-group.yml
@@ -1,0 +1,56 @@
+# If the workflow trigger is "merge_group", run the automated tests.
+
+name: merge-group-test
+
+on:
+  merge_group:
+
+permissions:
+  id-token: write
+  contents: read
+
+defaults:
+  run:
+    # We need -e -o pipefail for consistency with GitHub Actions' default behavior
+    shell: bash -e -o pipefail {0}
+
+jobs:
+  # Run the E2E insecure tests on the commercial account
+  e2e-commercial-insecure:
+    runs-on: ubuntu-latest
+    needs: parse
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.PAT }}
+          repository: ${{ github.event.client_payload.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event.client_payload.pull_request.head.ref || github.ref_name }}
+      - name: Run E2E Tests
+        uses: ./.github/actions/e2e
+        with:
+          token: ${{ secrets.PAT }}
+          role-to-assume: ${{ secrets.AWS_COMMERCIAL_ROLE_TO_ASSUME }}
+          region: us-east-2
+          github-context: "test / e2e-commercial-insecure"
+          test-to-run: "insecure"
+
+  # Run the E2E secure tests on the govcloud account
+  e2e-govcloud-secure:
+    runs-on: ubuntu-latest
+    needs: parse
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.PAT }}
+          repository: ${{ github.event.client_payload.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event.client_payload.pull_request.head.ref || github.ref_name }}
+      - name: Run E2E Tests
+        uses: ./.github/actions/e2e
+        with:
+          token: ${{ secrets.PAT }}
+          role-to-assume: ${{ secrets.AWS_GOVCLOUD_ROLE_TO_ASSUME }}
+          region: us-gov-east-1
+          github-context: "test / e2e-govcloud-secure"
+          test-to-run: "secure"

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,7 +1,10 @@
+# If the workflow trigger is "pull_request" or "merge_group", run the pre-commit checks.
+
 name: pre-commit
 
 on:
   pull_request:
+  merge_group:
 
 jobs:
   common:

--- a/.github/workflows/pull-request-opened-by-renovate.yml
+++ b/.github/workflows/pull-request-opened-by-renovate.yml
@@ -1,4 +1,10 @@
-# This autoformats using pre-commit, then triggers an automatic test run if and only if Renovate is the author and the PR was just opened. See ADR #0008.
+# If Renovate is not the author of the PR that triggers this workflow, it will do nothing.
+# If Renovate is the author of the PR that triggers this workflow, but the workflow event is anything but "opened", it will do nothing.
+# If Renovate is the author of the PR that triggers this workflow, and the workflow event is "opened", it will:
+#   1. Autoformat using pre-commit and, if necessary, push an additional commit to the PR with the autoformat fixes.
+#   2. Add the "/test all" comment to the PR, so that the Slash Command Dispatch workflow is triggered automatically.
+#
+# See ADR #0008.
 name: auto-test
 on:
   pull_request:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,3 +1,5 @@
+# On every push to main, run release-please to automatically handle the release process.
+
 name: release-please
 
 on:

--- a/.github/workflows/slash-command-dispatch.yml
+++ b/.github/workflows/slash-command-dispatch.yml
@@ -1,3 +1,6 @@
+# When someone with write access to the repo adds a comment to a PR that contains "/test <command>", dispatch the workflow found in "test-command.yml"
+# When someone with write access to the repo adds a comment to a PR that contains "/update <command>", dispatch the workflow found in "update-command.yml"
+
 name: Slash Command Dispatch
 on:
   issue_comment:

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -1,3 +1,5 @@
+# This workflow is triggered by a comment on a pull request. The comment must contain "/test <command>" to trigger the workflow.
+
 # Attribution for a bunch of this goes to CloudPosse
 # https://github.com/cloudposse/actions/blob/master/.github/workflows/test-command.yml
 

--- a/.github/workflows/update-command.yml
+++ b/.github/workflows/update-command.yml
@@ -1,3 +1,5 @@
+# This workflow is triggered by a comment on a pull request. The comment must contain "/update <command>" to trigger the workflow.
+
 name: update
 on:
   repository_dispatch:


### PR DESCRIPTION
Nothing should change, even after we merge, until we go into the branch protection settings and enable the merge queue.