### PR TITLE
chore(ci): Fix typo in merge_group test jobs

### DIFF
--- a/.github/workflows/merge-group.yml
+++ b/.github/workflows/merge-group.yml
@@ -18,7 +18,6 @@ jobs:
   # Run the E2E insecure tests on the commercial account
   e2e-commercial-insecure:
     runs-on: ubuntu-latest
-    needs: parse
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
@@ -38,7 +37,6 @@ jobs:
   # Run the E2E secure tests on the govcloud account
   e2e-govcloud-secure:
     runs-on: ubuntu-latest
-    needs: parse
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3


### PR DESCRIPTION
The `needs:` lines shouldn't have been there, was causing the tests to not run