### PR TITLE
ci: implement hacky thing to only have e2e tests run in merge queue

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
 BUILD_HARNESS_REPO=ghcr.io/defenseunicorns/build-harness/build-harness
 # renovate: datasource=github-tags depName=defenseunicorns/build-harness
-BUILD_HARNESS_VERSION=1.11.0
+BUILD_HARNESS_VERSION=1.11.1

--- a/.github/workflows/auto-success.yml
+++ b/.github/workflows/auto-success.yml
@@ -35,7 +35,7 @@ jobs:
           REPO_SHA: ${{ github.event.client_payload.pull_request.head.sha || github.event.pull_request.head.sha || github.sha }}
           REPO_NAME: ${{ github.event.client_payload.github.payload.repository.name || github.event.repository.name }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_CONTEXT:  "test / e2e-govcloud-insecure"
+          GITHUB_CONTEXT:  "test / e2e-govcloud-secure"
           GITHUB_DESCRIPTION: "started by @${{ github.event.client_payload.github.actor || github.actor }}"
           GITHUB_TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
           GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref || github.event.pull_request.head.ref || github.ref_name }}

--- a/.github/workflows/auto-success.yml
+++ b/.github/workflows/auto-success.yml
@@ -10,26 +10,31 @@ jobs:
   report-status:
     runs-on:  ubuntu-latest
     steps:
+      - name: debug
+        uses: hmarr/debug-action@v2
+
       - name: update e2e-commercial-insecure success
         uses: docker://cloudposse/github-status-updater
         with:
-          args: "-action update_state -state pending -ref ${{ env.REPO_SHA }} -repo ${{ env.REPO_NAME }}"
+          args: "-action update_state -state success"
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_CONTEXT:  "test / e2e-commercial-insecure"
           GITHUB_DESCRIPTION: "started by @${{ github.event.client_payload.github.actor || github.actor }}"
           GITHUB_TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
           GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref || github.event.pull_request.head.ref || github.ref_name }}
           GITHUB_OWNER: ${{ github.event.client_payload.github.payload.repository.owner.login || github.repository_owner }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPO: ${{ github.event.client_payload.github.payload.repository.name || github.repository_name }}
 
       - name: update e2e-govcloud-secure success
         uses: docker://cloudposse/github-status-updater
         with:
-          args: "-action update_state -state pending -ref ${{ env.REPO_SHA }} -repo ${{ env.REPO_NAME }}"
+          args: "-action update_state -state success"
         env:
-          GITHUB_CONTEXT:  "test / e2e-govcloud-secure"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_CONTEXT:  "test / e2e-commercial-insecure"
           GITHUB_DESCRIPTION: "started by @${{ github.event.client_payload.github.actor || github.actor }}"
           GITHUB_TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
           GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref || github.event.pull_request.head.ref || github.ref_name }}
           GITHUB_OWNER: ${{ github.event.client_payload.github.payload.repository.owner.login || github.repository_owner }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPO: ${{ github.event.client_payload.github.payload.repository.name || github.repository_name }}

--- a/.github/workflows/auto-success.yml
+++ b/.github/workflows/auto-success.yml
@@ -16,27 +16,27 @@ jobs:
       - name: update e2e-commercial-insecure success
         uses: docker://cloudposse/github-status-updater
         with:
-          args: "-action update_state -state success -ref ${{ env.REPO_SHA }} -repo ${{ env.GITHUB_REPO }}"
+          args: "-action update_state -state success -ref ${{ env.REPO_SHA }} -repo ${{ env.REPO_NAME }}"
         env:
           REPO_SHA: ${{ github.event.client_payload.pull_request.head.sha || github.event.pull_request.head.sha || github.sha }}
+          REPO_NAME: ${{ github.event.client_payload.github.payload.repository.name || github.event.repository.name }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_CONTEXT:  "test / e2e-commercial-insecure"
           GITHUB_DESCRIPTION: "started by @${{ github.event.client_payload.github.actor || github.actor }}"
           GITHUB_TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
           GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref || github.event.pull_request.head.ref || github.ref_name }}
           GITHUB_OWNER: ${{ github.event.client_payload.github.payload.repository.owner.login || github.repository_owner }}
-          GITHUB_REPO: ${{ github.event.client_payload.github.payload.repository.name || github.repository_name }}
 
       - name: update e2e-govcloud-secure success
         uses: docker://cloudposse/github-status-updater
         with:
-          args: "-action update_state -state success -ref ${{ env.REPO_SHA }} -repo ${{ env.GITHUB_REPO }}"
+          args: "-action update_state -state success -ref ${{ env.REPO_SHA }} -repo ${{ env.REPO_NAME }}"
         env:
           REPO_SHA: ${{ github.event.client_payload.pull_request.head.sha || github.event.pull_request.head.sha || github.sha }}
+          REPO_NAME: ${{ github.event.client_payload.github.payload.repository.name || github.event.repository.name }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_CONTEXT:  "test / e2e-govcloud-insecure"
           GITHUB_DESCRIPTION: "started by @${{ github.event.client_payload.github.actor || github.actor }}"
           GITHUB_TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
           GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref || github.event.pull_request.head.ref || github.ref_name }}
           GITHUB_OWNER: ${{ github.event.client_payload.github.payload.repository.owner.login || github.repository_owner }}
-          GITHUB_REPO: ${{ github.event.client_payload.github.payload.repository.name || github.repository_name }}

--- a/.github/workflows/auto-success.yml
+++ b/.github/workflows/auto-success.yml
@@ -15,9 +15,10 @@ jobs:
 
       - name: update e2e-commercial-insecure success
         uses: docker://cloudposse/github-status-updater
+        with:
+          args: "-action update_state -state success -ref ${{ env.REPO_SHA }} -repo ${{ env.GITHUB_REPO }}"
         env:
-          GITHUB_ACTION: update_state
-          GITHUB_STATE: success
+          REPO_SHA: ${{ github.event.client_payload.pull_request.head.sha || github.event.pull_request.head.sha || github.sha }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_CONTEXT:  "test / e2e-commercial-insecure"
           GITHUB_DESCRIPTION: "started by @${{ github.event.client_payload.github.actor || github.actor }}"
@@ -28,11 +29,12 @@ jobs:
 
       - name: update e2e-govcloud-secure success
         uses: docker://cloudposse/github-status-updater
+        with:
+          args: "-action update_state -state success -ref ${{ env.REPO_SHA }} -repo ${{ env.GITHUB_REPO }}"
         env:
-          GITHUB_ACTION: update_state
-          GITHUB_STATE: success
+          REPO_SHA: ${{ github.event.client_payload.pull_request.head.sha || github.event.pull_request.head.sha || github.sha }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_CONTEXT:  "test / e2e-commercial-insecure"
+          GITHUB_CONTEXT:  "test / e2e-govcloud-insecure"
           GITHUB_DESCRIPTION: "started by @${{ github.event.client_payload.github.actor || github.actor }}"
           GITHUB_TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
           GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref || github.event.pull_request.head.ref || github.ref_name }}

--- a/.github/workflows/auto-success.yml
+++ b/.github/workflows/auto-success.yml
@@ -22,7 +22,7 @@ jobs:
           REPO_NAME: ${{ github.event.client_payload.github.payload.repository.name || github.event.repository.name }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_CONTEXT:  "test / e2e-commercial-insecure"
-          GITHUB_DESCRIPTION: "started by @${{ github.event.client_payload.github.actor || github.actor }}"
+          GITHUB_DESCRIPTION: "auto-success, not a real status to merge into main"
           GITHUB_TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
           GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref || github.event.pull_request.head.ref || github.ref_name }}
           GITHUB_OWNER: ${{ github.event.client_payload.github.payload.repository.owner.login || github.repository_owner }}
@@ -36,7 +36,7 @@ jobs:
           REPO_NAME: ${{ github.event.client_payload.github.payload.repository.name || github.event.repository.name }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_CONTEXT:  "test / e2e-govcloud-secure"
-          GITHUB_DESCRIPTION: "started by @${{ github.event.client_payload.github.actor || github.actor }}"
+          GITHUB_DESCRIPTION: "auto-success, not a real status to merge into main"
           GITHUB_TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
           GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref || github.event.pull_request.head.ref || github.ref_name }}
           GITHUB_OWNER: ${{ github.event.client_payload.github.payload.repository.owner.login || github.repository_owner }}

--- a/.github/workflows/auto-success.yml
+++ b/.github/workflows/auto-success.yml
@@ -1,0 +1,35 @@
+# If the workflow trigger is "pull_request", auto-succeed required checks.
+# these tests will be handled in the merge_group workflow (merge queue)
+name: auto-success
+
+on:
+  pull_request:
+
+jobs:
+
+  report-status:
+    runs-on:  ubuntu-latest
+    steps:
+      - name: update e2e-commercial-insecure success
+        uses: docker://cloudposse/github-status-updater
+        with:
+          args: "-action update_state -state pending -ref ${{ env.REPO_SHA }} -repo ${{ env.REPO_NAME }}"
+        env:
+          GITHUB_CONTEXT:  "test / e2e-commercial-insecure"
+          GITHUB_DESCRIPTION: "started by @${{ github.event.client_payload.github.actor || github.actor }}"
+          GITHUB_TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref || github.event.pull_request.head.ref || github.ref_name }}
+          GITHUB_OWNER: ${{ github.event.client_payload.github.payload.repository.owner.login || github.repository_owner }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: update e2e-govcloud-secure success
+        uses: docker://cloudposse/github-status-updater
+        with:
+          args: "-action update_state -state pending -ref ${{ env.REPO_SHA }} -repo ${{ env.REPO_NAME }}"
+        env:
+          GITHUB_CONTEXT:  "test / e2e-govcloud-secure"
+          GITHUB_DESCRIPTION: "started by @${{ github.event.client_payload.github.actor || github.actor }}"
+          GITHUB_TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref || github.event.pull_request.head.ref || github.ref_name }}
+          GITHUB_OWNER: ${{ github.event.client_payload.github.payload.repository.owner.login || github.repository_owner }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/auto-success.yml
+++ b/.github/workflows/auto-success.yml
@@ -15,9 +15,9 @@ jobs:
 
       - name: update e2e-commercial-insecure success
         uses: docker://cloudposse/github-status-updater
-        with:
-          args: "-action update_state -state success"
         env:
+          GITHUB_ACTION: update_state
+          GITHUB_STATE: success
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_CONTEXT:  "test / e2e-commercial-insecure"
           GITHUB_DESCRIPTION: "started by @${{ github.event.client_payload.github.actor || github.actor }}"
@@ -28,9 +28,9 @@ jobs:
 
       - name: update e2e-govcloud-secure success
         uses: docker://cloudposse/github-status-updater
-        with:
-          args: "-action update_state -state success"
         env:
+          GITHUB_ACTION: update_state
+          GITHUB_STATE: success
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_CONTEXT:  "test / e2e-commercial-insecure"
           GITHUB_DESCRIPTION: "started by @${{ github.event.client_payload.github.actor || github.actor }}"


### PR DESCRIPTION
basically, auto-success runs in PRs (`pull_request`), actual e2e will run in merge queue (`merge_group`) and then be merged on success

you can add a PR to the merge queue without actually doing an e2e test and removing duplication of testing for something to make it into main