### PR TITLE
Switch Renovate's `rebaseWhen` to "never"

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -21,8 +21,8 @@
     "after 7am and before 9am every weekday"
   ],
   // This will prevent Renovate from automatically rebasing PRs. Without this, Renovate will rebase PRs whenever it wants to. The 'schedule' param is only for creating PRs. Because we are grouping all changes into one PR without this Renovate will be constantly rebasing that PR which we don't want since every time that happens another set of GHA status checks are kicked off.
-  // Using a value of "conflicted" means that Renovate will only rebase PRs if they are in a conflicted state. See https://docs.renovatebot.com/configuration-options/#rebasewhen
-  rebaseWhen: "conflicted",
+  // See https://docs.renovatebot.com/configuration-options/#rebasewhen
+  rebaseWhen: "never",
   // Labels to set in Pull Request. See https://docs.renovatebot.com/configuration-options/#labels
   labels: [
     "renovate"


### PR DESCRIPTION
Renovate is rebasing the PR too many times. Lately it is doing it before the tests can even finish running. Changing this field to `never` will stop Renovate from rebasing a PR. It can be rebased manually by clicking the checkbox at the bottom of the PR description.

<img width="1049" alt="image" src="https://github.com/defenseunicorns/delivery-aws-iac/assets/16000938/fc1a61b7-3b26-45f6-a15e-7a2619aaa2d2">
