### PR TITLE
ci: fix permissions issues and move release-please to reusable workflow

### DIFF
--- a/.github/workflows/pr-merge-group.yml
+++ b/.github/workflows/pr-merge-group.yml
@@ -10,6 +10,10 @@ defaults:
   run:
     shell: bash -eo pipefail {0}
 
+permissions:
+  id-token: write # needed for oidc auth for AWS creds
+  contents: read
+
 jobs:
   pr-merge-group-test:
     uses: defenseunicorns/delivery-github-actions-workflows/.github/workflows/pr-merge-group-test.yml@main

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,17 +13,7 @@ permissions:
 
 jobs:
   release-please:
-    runs-on: ubuntu-latest
-    steps:
-
-      - name: Get token
-        id: get_workflow_token
-        uses: peter-murray/workflow-application-token-action@v2
-        with:
-          application_id: ${{ secrets.NARWHAL_BOT_APP_ID }}
-          application_private_key: ${{ secrets.NARWHAL_BOT_SECRET }}
-
-      - uses: google-github-actions/release-please-action@v3
-        with:
-          token: ${{ steps.get_workflow_token.outputs.token }}
-          command: manifest
+    uses: defenseunicorns/delivery-github-actions-workflows/.github/workflows/release-please.yml@main
+    secrets:
+      APPLICATION_ID: ${{ secrets.NARWHAL_BOT_APP_ID }}
+      APPLICATION_PRIVATE_KEY: ${{ secrets.NARWHAL_BOT_SECRET }}

--- a/.github/workflows/scheduled-e2e-secure-test.yml
+++ b/.github/workflows/scheduled-e2e-secure-test.yml
@@ -9,6 +9,10 @@ defaults:
   run:
     shell: bash -eo pipefail {0}
 
+permissions:
+  id-token: write # needed for oidc auth for AWS creds
+  contents: read
+
 jobs:
   scheduled-e2e-secure-test:
     uses: defenseunicorns/delivery-github-actions-workflows/.github/workflows/secure-test-with-chatops.yml@main


### PR DESCRIPTION
Permissions need to be set at caller workflow. Reusable (called) workflows may not have more permissions than the caller workflow. If you set any permissions, any permissions not set are set to `none`, so we need to keep that in mind.

We may want to look at adding permissions at the job level, I'm not sure how that interaction works with reusable workflows, but it is a bit more annoying to set it in multiple places. 

Specifically the `GITHUB_TOKEN` for our IaC tests needs `id-token: write` for OIDC AWS auth things and that needs to be set at the top level workflow if set at the workflow level